### PR TITLE
Leverage serialized engine to speed-up CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 
 import path from 'node:path';
-import { existsSync, readFileSync } from 'node:fs';
-import { FiltersEngine, Request } from '@cliqz/adblocker';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { FiltersEngine, Request, ENGINE_VERSION } from '@cliqz/adblocker';
 
 import { BASE_PATH } from './scripts/helpers.js';
 
+const debug = process.env.DEBUG === 'true' ? console.log : () => {};
+
 (async () => {
+  const startTime = Date.now();
   const [, , url] = process.argv;
 
   if (!url) {
@@ -14,33 +17,52 @@ import { BASE_PATH } from './scripts/helpers.js';
     process.exit(1);
   }
 
+  // Generate input JSON if missing
   const trackerDBPath = path.join(BASE_PATH, 'dist', 'trackerdb.json');
-
   if (!existsSync(trackerDBPath)) {
-    // generate input JSON if missing
     await import('./scripts/export-json/index.js');
   }
 
-  const rawTrackerDB = JSON.parse(readFileSync(trackerDBPath, 'utf-8'));
-
-  const engine = FiltersEngine.fromTrackerDB(rawTrackerDB);
-
-  let matches = [];
-
-  if (url.startsWith('http')) {
-    const request = Request.fromRawDetails({ url });
-    matches = engine.getPatternMetadata(request);
-  } else {
-    matches = engine.metadata.fromDomain(url);
+  // Generate binary engine if missing
+  const trackerEnginePath = path.join(
+    BASE_PATH,
+    'dist',
+    `trackerdb_${ENGINE_VERSION}.engine`,
+  );
+  if (!existsSync(trackerEnginePath)) {
+    const rawTrackerDB = JSON.parse(readFileSync(trackerDBPath, 'utf-8'));
+    const engine = FiltersEngine.fromTrackerDB(rawTrackerDB);
+    writeFileSync(trackerEnginePath, engine.serialize());
   }
+
+  const loadingStart = Date.now();
+  const engine = FiltersEngine.deserialize(readFileSync(trackerEnginePath));
+  const loadingEnd = Date.now();
+
+  const matches = url.startsWith('http')
+    ? engine.getPatternMetadata(Request.fromRawDetails({ url }))
+    : engine.metadata.fromDomain(url);
+  const matchingEnd = Date.now();
+
+  debug('Timing:', {
+    init: loadingStart - startTime,
+    loading: loadingEnd - loadingStart,
+    matching: matchingEnd - loadingEnd,
+    total: matchingEnd - startTime,
+  });
 
   if (matches.length === 0) {
     console.log('No matches found');
   } else {
-    const results = {
-      url,
-      matches,
-    };
-    console.log(JSON.stringify(results, null, 2));
+    console.log(
+      JSON.stringify(
+        {
+          url,
+          matches,
+        },
+        null,
+        2,
+      ),
+    );
   }
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ghostery/trackerdb",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ghostery/trackerdb",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "CC-BY-NC-SA-4.0",
       "dependencies": {
         "@cliqz/adblocker": "^1.26.0",
@@ -960,9 +960,9 @@
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "optional": true
     },
     "node_modules/http-proxy-agent": {
@@ -1123,11 +1123,11 @@
       "devOptional": true
     },
     "node_modules/iso-3166-1-alpha-2": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/iso-3166-1-alpha-2/-/iso-3166-1-alpha-2-1.0.0.tgz",
-      "integrity": "sha1-vJ4LuU5YTfVGipMpl6KFUuJvl6w=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/iso-3166-1-alpha-2/-/iso-3166-1-alpha-2-1.0.1.tgz",
+      "integrity": "sha512-hehv4FOIieRgJ4+AOdRptTB0wD6nSX85O731hGin0ZbLCyeQ+rVMtvUPBnsnjJCDgG5jCRtU4wGHXE85lSJk9Q==",
       "dependencies": {
-        "mout": "^0.11.0"
+        "mout": "^1.2.3"
       }
     },
     "node_modules/js-yaml": {
@@ -1344,9 +1344,9 @@
       }
     },
     "node_modules/mout": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
-      "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/mout/-/mout-1.2.4.tgz",
+      "integrity": "sha512-mZb9uOruMWgn/fw28DG4/yE3Kehfk1zKCLhuDU2O3vlKdnBBr4XaOCqVTflJ5aODavGUPqFHZgrFX3NJVuxGhQ=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -2796,9 +2796,9 @@
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "optional": true
     },
     "http-proxy-agent": {
@@ -2926,11 +2926,11 @@
       "devOptional": true
     },
     "iso-3166-1-alpha-2": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/iso-3166-1-alpha-2/-/iso-3166-1-alpha-2-1.0.0.tgz",
-      "integrity": "sha1-vJ4LuU5YTfVGipMpl6KFUuJvl6w=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/iso-3166-1-alpha-2/-/iso-3166-1-alpha-2-1.0.1.tgz",
+      "integrity": "sha512-hehv4FOIieRgJ4+AOdRptTB0wD6nSX85O731hGin0ZbLCyeQ+rVMtvUPBnsnjJCDgG5jCRtU4wGHXE85lSJk9Q==",
       "requires": {
-        "mout": "^0.11.0"
+        "mout": "^1.2.3"
       }
     },
     "js-yaml": {
@@ -3096,9 +3096,9 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mout": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
-      "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/mout/-/mout-1.2.4.tgz",
+      "integrity": "sha512-mZb9uOruMWgn/fw28DG4/yE3Kehfk1zKCLhuDU2O3vlKdnBBr4XaOCqVTflJ5aODavGUPqFHZgrFX3NJVuxGhQ=="
     },
     "ms": {
       "version": "2.1.2",


### PR DESCRIPTION
Before (milliseconds): init: 3, loading: 143, matching: 1, total: 147
After (milliseconds): init: 2, loading: 7, matching: 2, total: 11

Also ran `npm audit fix`