### PR TITLE
Change Cookiebot category to consent

### DIFF
--- a/db/patterns/cookiebot.eno
+++ b/db/patterns/cookiebot.eno
@@ -1,5 +1,5 @@
 name: Cookiebot
-category: essential
+category: consent
 website_url: https://www.cookiebot.com/en/
 organization: cybot
 


### PR DESCRIPTION
Cookiebot seems to have more overlap with the new "consent" category than with "essential".