### PR TITLE
Change OneTrust category to consent

### DIFF
--- a/db/patterns/onetrust.eno
+++ b/db/patterns/onetrust.eno
@@ -1,5 +1,5 @@
 name: OneTrust
-category: essential
+category: consent
 website_url: https://www.onetrust.com/
 organization: onetrust
 


### PR DESCRIPTION
OneTrust seems to have more overlap with the new "consent" category than with "essential".
