### PR TITLE
Improve Google Analytics detection

### DIFF
--- a/db/patterns/google_analytics.eno
+++ b/db/patterns/google_analytics.eno
@@ -5,6 +5,7 @@ organization: google
 
 --- domains
 google-analytics.com
+region1.google-analytics.com
 --- domains
 
 --- filters


### PR DESCRIPTION
Test page: https://www.moddb.com/

This request shows up as unidentified tracker, but belongs to Google Analytics:

```
https://region1.google-analytics.com/g/collect?v=2&tid=G-VBMFL9G8M0&gtm=45je37q0&_p=1635236402&gcs=G100&cid=47630819.1690473430&ul=en-us&sr=1920x1200&_s=2&sid=1690473430&sct=1&seg=0&dl=https%3A%2F%2Fwww.moddb.com%2F&dt=Games%20and%20mods%20development%20for%20Windows%2C%20Linux%20and%20Mac%20-%20Mod%20DB&en=user_engagement&ep.anonymize_ip=true&ep.store_gac=false&_et=2756
```