### PR TITLE
Adds ghostery_id for id5 sync

### DIFF
--- a/db/patterns/id5_sync.eno
+++ b/db/patterns/id5_sync.eno
@@ -12,3 +12,5 @@ eu-1-id5-sync.com
 ||id5-sync.com^$3p
 ||eu-1-id5-sync.com^3p
 --- filters
+
+ghostery_id: 4057


### PR DESCRIPTION
Otherwise, the patterns gets rejected as invalid by the adblocker engine (https://github.com/ghostery/adblocker/blob/10f60979a6a6af62ed3832ec077eca186913b33a/packages/adblocker/src/engine/metadata/patterns.ts#L76)

refs https://github.com/ghostery/trackerdb/issues/31 refs https://github.com/ghostery/trackerdb/pull/41