### PR TITLE
Include detection patterns for OneTrust (and Optanaon)

### DIFF
--- a/db/patterns/onetrust.eno
+++ b/db/patterns/onetrust.eno
@@ -7,4 +7,22 @@ organization: onetrust
 onetrust.com
 --- domains
 
+--- filters
+###onetrust-banner-sdk
+###onetrust-consent-sdk
+##.onetrust-pc-dark-filter
+##.js-consent-banner
+###cookie-preferences
+###consent_blackbar
+||onetrust.com^$third-party
+/onetrustConsent.js
+/onetrust/consent/*
+/js/onetrust/*
+###ot-sdk-btn:not(button)
+##.ot-sdk-show-settings
+###teconsent
+/onetrust.
+/otbannersdk.js
+--- filters
+
 ghostery_id: 3740

--- a/db/patterns/onetrust.eno
+++ b/db/patterns/onetrust.eno
@@ -11,7 +11,6 @@ onetrust.com
 ###onetrust-banner-sdk
 ###onetrust-consent-sdk
 ##.onetrust-pc-dark-filter
-##.js-consent-banner
 ###cookie-preferences
 ###consent_blackbar
 ||onetrust.com^$third-party

--- a/db/patterns/optanaon.eno
+++ b/db/patterns/optanaon.eno
@@ -7,4 +7,8 @@ organization: onetrust
 cookielaw.org
 --- domains
 
+--- filters
+##.optanon-toggle-display
+--- filters
+
 ghostery_id: 3742


### PR DESCRIPTION
Adds patterns to detect OneTrust/Optananon

Note: the patterns may be incomplete, but the came from https://github.com/ghostery/broken-page-reports/issues/336 and https://github.com/ghostery/broken-page-reports/issues/357. These issues also provide test pages.