### PR TITLE
Split CDN parts of Gigya into its separate entry

### DIFF
--- a/db/patterns/gigya.eno
+++ b/db/patterns/gigya.eno
@@ -1,6 +1,6 @@
 name: Gigya
 category: site_analytics
-website_url: 
+website_url: https://www.sap.com/products/acquired-brands/what-is-gigya.html
 organization: sap
 
 --- domains
@@ -12,10 +12,6 @@ gigya.com
 --- filters
 /js/gigya-sharebar.min.js
 ||analytics.gigyahosting1.com/gigya-analytics.js
-||cdn.gigya.com/js
-||cdns.gigya.com^$3p
-||cdns.us1.gigya.com^$3p
-||cdns2.gigya.com^$3p
 ||gigya.com/js/gigyagaintegration.js
 ||gscounters.us1.gigya.com^$3p
 --- filters

--- a/db/patterns/gigya_beacon.eno
+++ b/db/patterns/gigya_beacon.eno
@@ -1,6 +1,6 @@
 name: Gigya Beacon
 category: customer_interaction
-website_url: http://www.gigya.com
+website_url: https://www.sap.com/products/acquired-brands/what-is-gigya.html
 organization: sap
 alias: gigya
 

--- a/db/patterns/gigya_cdn.eno
+++ b/db/patterns/gigya_cdn.eno
@@ -1,0 +1,18 @@
+name: Gigya CDN
+category: cdn
+website_url: https://www.sap.com/products/acquired-brands/what-is-gigya.html
+organization: sap
+
+--- domains
+cdns.gigya.com
+cdns.us1.gigya.com
+cdns2.gigya.com
+--- domains
+
+--- filters
+||cdns.gigya.com^$3p
+||cdns.us1.gigya.com^$3p
+||cdns2.gigya.com^$3p
+--- filters
+
+ghostery_id: 4064

--- a/db/patterns/gigya_socialize.eno
+++ b/db/patterns/gigya_socialize.eno
@@ -1,6 +1,6 @@
 name: Gigya Socialize
 category: customer_interaction
-website_url: http://www.gigya.com
+website_url: https://www.sap.com/products/acquired-brands/what-is-gigya.html
 organization: sap
 alias: gigya
 

--- a/db/patterns/gigya_toolbar.eno
+++ b/db/patterns/gigya_toolbar.eno
@@ -1,6 +1,6 @@
 name: Gigya Toolbar
 category: customer_interaction
-website_url: http://www.gigya.com/
+website_url: https://www.sap.com/products/acquired-brands/what-is-gigya.html
 organization: sap
 alias: gigya
 


### PR DESCRIPTION
Split CDN parts of Gigya into its separate entry but without the overlapping rule `||cdn.gigya.com/js` (which clashes with https://github.com/ghostery/trackerdb/blob/9e16bd129fc34d3c1881ac0f0a70b21cb25d1188/db/patterns/gigya_socialize.eno#L8)

Intended to reduced breakage caused by overly aggressive blocking.

refs https://github.com/ghostery/broken-page-reports/issues/390