### PR TITLE
Add Nexon

### DIFF
--- a/db/organizations/nexon.eno
+++ b/db/organizations/nexon.eno
@@ -1,11 +1,9 @@
-name: Nexon Global
+name: Nexon
 website_url: https://www.nexon.com/main/en
 privacy_policy_url: https://www.nexon.com/main/en/legal/privacy
 privacy_contact: NA_privacy@nexon.com
-country: US
-description: "Nexon Global is developing multiplayer online role-playing games (MMORPG)."
+country: JP
+description: "Nexon Co., Ltd. is a Japanese video game publisher. Headquartered in Japan, the company has offices in South Korea, the United States, Taiwan and Thailand. Nexon was founded in Seoul, South Korea, in 1994. In 2005, the company moved its headquarters to Tokyo, Japan."
 
 --- notes
 --- notes
-
-ghostery_id:

--- a/db/organizations/nexon.eno
+++ b/db/organizations/nexon.eno
@@ -1,0 +1,11 @@
+name: Nexon Global
+website_url: https://www.nexon.com/main/en
+privacy_policy_url: https://www.nexon.com/main/en/legal/privacy
+privacy_contact: NA_privacy@nexon.com
+country: US
+description: "Nexon Global is developing multiplayer online role-playing games (MMORPG)."
+
+--- notes
+--- notes
+
+ghostery_id:

--- a/db/patterns/nexon.eno
+++ b/db/patterns/nexon.eno
@@ -1,0 +1,16 @@
+name: Nexon Global
+category: site_analytics
+website_url: https://www.nexon.com/main/en
+organization: nexon
+
+--- domains
+ssl.nexon.com
+public.api.nexon.com
+--- domains
+
+--- filters
+||ssl.nexon.com/s1/da/a2s.js
+||public.api.nexon.com/nxlog-collect/apne2/client.all
+--- filters
+
+ghostery_id:

--- a/db/patterns/nexon.eno
+++ b/db/patterns/nexon.eno
@@ -1,4 +1,4 @@
-name: Nexon Global
+name: Nexon
 category: site_analytics
 website_url: https://www.nexon.com/main/en
 organization: nexon
@@ -12,5 +12,3 @@ public.api.nexon.com
 ||ssl.nexon.com/s1/da/a2s.js
 ||public.api.nexon.com/nxlog-collect/apne2/client.all
 --- filters
-
-ghostery_id:


### PR DESCRIPTION
This PR adds Nexon Global with analytics pattern.

## Must-reviewed

### This PR doesn't include `ghostery_id` field.

I'd like to add the field after figuring out how `ghostery_id` is assigned and managed.

### The management of the site analytics endpoint is owned and done by Nexon Korea.

Nexon's site analytics endpoint is often integrated with other tools like Google Analytics and their games. However, they have privacy policy in each languages because they own multiple companies over the world.

If it's important to focus on their nationality and the subjectivity, I think it's better to put Nexon Korea.

However, if you value the accessibility over other values, I think Nexon Global fits better here because they write things in English.