### PR TITLE
Improve detection of Naver Corp.

### DIFF
--- a/db/patterns/naver.com.eno
+++ b/db/patterns/naver.com.eno
@@ -6,13 +6,12 @@ organization: naver
 --- domains
 naver.com
 naver.net
-pstatic.net
 --- domains
 
 --- filters
 ||search.naver.com^$3p
 ||wcs.naver.net/wcslog.js
-||siape.veta.naver.com
+||siape.veta.naver.com^$3p
 ||event.impression-neo.naver.com
 ||ssl.pstatic.net/adimg3.search/adpost/js/event_tracker.js
 --- filters

--- a/db/patterns/naver.com.eno
+++ b/db/patterns/naver.com.eno
@@ -6,12 +6,15 @@ organization: naver
 --- domains
 naver.com
 naver.net
+pstatic.net
 --- domains
 
 --- filters
 ||search.naver.com^$3p
 ||wcs.naver.net/wcslog.js
 ||siape.veta.naver.com
+||event.impression-neo.naver.com
+||ssl.pstatic.net/adimg3.search/adpost/js/event_tracker.js
 --- filters
 
 ghostery_id: 2456

--- a/db/patterns/naver.com.eno
+++ b/db/patterns/naver.com.eno
@@ -11,6 +11,7 @@ naver.net
 --- filters
 ||search.naver.com^$3p
 ||wcs.naver.net/wcslog.js
+||siape.veta.naver.com
 --- filters
 
 ghostery_id: 2456


### PR DESCRIPTION
### pstatic.net

`pstatic.net` is the CDN domain owned by Naver: https://lookup.icann.org/en/lookup

You can find network requests to `pstatic.net` on `https://search.naver.com/search.naver?where=nexearch&sm=top_hty&fbm=0&ie=utf8&query=Google`.

### adcr.naver.com

`adcr.naver.com` is advertising system of Naver and often used to collect marketing impression data as first party. For example, Naver ads in non-naver websites often pass `adcr.naver.com` with impression data. However, it's too risky to block `adcr.naver.com` because they're deeply linked into Naver's internal services like flight booking.