### PR TITLE
Add Kakao, Daum.net, and Tiara

### DIFF
--- a/db/organizations/kakao.eno
+++ b/db/organizations/kakao.eno
@@ -1,7 +1,7 @@
 name: Kakao
 website_url: https://www.kakaocorp.com/page/
 privacy_policy_url: https://www.kakao.com/policy/privacy?lang=en
-privacy_contact:
+privacy_contact: https://cs.kakao.com/requests?category=1&locale=en&node=30288&service=8&select=combo2
 country: KR
 description: Kakao Corp is the company behind KakaoTalk, which serves as its main platform and flagship application.
 

--- a/db/organizations/kakao.eno
+++ b/db/organizations/kakao.eno
@@ -1,0 +1,9 @@
+name: Kakao
+website_url: https://www.kakaocorp.com/page/
+privacy_policy_url: https://www.kakao.com/policy/privacy?lang=en
+privacy_contact:
+country: KR
+description: Kakao Corp is the company behind KakaoTalk, which serves as its main platform and flagship application.
+
+--- notes
+--- notes

--- a/db/patterns/daum.net.eno
+++ b/db/patterns/daum.net.eno
@@ -1,0 +1,10 @@
+name: Daum Search
+category: customer_interaction
+website_url: https://www.daum.net/
+organization: kakao
+alias: daum.net
+
+--- domains
+daum.net
+daumcdn.net
+--- domains

--- a/db/patterns/kakao_tiara.eno
+++ b/db/patterns/kakao_tiara.eno
@@ -1,0 +1,20 @@
+name: Kakao Tiara
+category: site_analytics
+website_url:
+organization: kakao
+
+--- domains
+stat.tiara.daum.net
+stage-stat.tiara.kakao.com
+stage-proxy-stat.tiara.kakao.com
+click.tiara.kakao.com
+www.tiara.kakao.com
+tiara.gl.kakao.com
+dev-stat.tiara.kakao.com
+tiara.kakao.com
+--- domains
+
+--- filters
+||stat.tiara.daum.net
+||t1.daumcdn.net/tiara/js/v1/tiara.min.js
+--- filters

--- a/db/patterns/kakao_tiara.eno
+++ b/db/patterns/kakao_tiara.eno
@@ -1,6 +1,6 @@
 name: Kakao Tiara
 category: site_analytics
-website_url:
+website_url: https://www.kakaocorp.com/page/
 organization: kakao
 
 --- domains


### PR DESCRIPTION
Kakao is Korean IT company just like Naver. While Naver holds the search market, Kakao holds messenger market. `daum.net` was a separate company provided search engine but merged to Kakao.

- https://en.wikipedia.org/wiki/Kakao

Tiara is tracking system developed by Kakao. They existed for a long time and widely-used in Kakao products not only search engines or web but also native apps.

There're some reports that blocking Tiara interrupts loading of some internal websites. However, they're resolvable by adding exception rules each time unlike Naver's `adcr.naver.com`. Also, cases rarely happened in my experience (e.g. once per a year).