### PR TITLE
Add Gabia and Cafe24

### DIFF
--- a/db/organizations/cafe24.eno
+++ b/db/organizations/cafe24.eno
@@ -1,0 +1,9 @@
+name: Cafe24
+website_url: https://global.cafe24.com/global/
+privacy_policy_url: https://global.cafe24.com/agreement/policy.html
+privacy_contact: global_support@cafe24.com
+country: KR
+description: "Cafe24 is a worldwide e-commerce platform that helps merchants establish their online DTC stores."
+
+--- notes
+--- notes

--- a/db/organizations/gabia.eno
+++ b/db/organizations/gabia.eno
@@ -1,0 +1,9 @@
+name: Gabia
+website_url: https://gabia.com/
+privacy_policy_url: https://policy.gabia.com/policy_collect
+privacy_contact: gprivacy@gabia.com
+country: KR
+description: "Gabia is providing IaaS type cloud service and SaaS type groupware which are required services for overall business IT department."
+
+--- notes
+--- notes

--- a/db/organizations/gabia.eno
+++ b/db/organizations/gabia.eno
@@ -3,7 +3,7 @@ website_url: https://gabia.com/
 privacy_policy_url: https://policy.gabia.com/policy_collect
 privacy_contact: gprivacy@gabia.com
 country: KR
-description: "Gabia is providing IaaS type cloud service and SaaS type groupware which are required services for overall business IT department."
+description: "Gabia is a cloud company located in Pangyo, Gyeonggi-do that provides a full range of services required for business IT, including IaaS-type cloud services, PaaS, and SaaS-type groupware solutions."
 
 --- notes
 --- notes

--- a/db/patterns/cafe24data.eno
+++ b/db/patterns/cafe24data.eno
@@ -1,0 +1,14 @@
+name: Cafe24 Analytics
+category: site_analytics
+website_url: https://developers.cafe24.com/docs/en/api/cafe24data
+organization: cafe24
+
+--- domains
+ca-api.cafe24data.com
+--- domains
+
+--- filters
+||ca-api.cafe24data.com$3p
+--- filters
+
+ghostery_id: 2365


### PR DESCRIPTION
Gabia and Cafe24 are WordPress or Wix-like eCommerce and website builder platform. They provide multiple services related to hosting like typical providers.

## Gabia

Unfortunately, Gabia doesn't include any patterns yet as I couldn't find any use of `*.gabia.io/gtag*` by searching online. I'll document this later if I find the use of Gabia Analytics API.

Also, no English version of the following document found:

- https://ko.wikipedia.org/wiki/%EA%B0%80%EB%B9%84%EC%95%84

## Cafe24

- https://github.com/yous/YousList/pull/294
- https://developers.cafe24.com/docs/en/api/cafe24data/#api-index