### PR TITLE
Add Airbridge

### DIFF
--- a/db/organizations/airbridge.eno
+++ b/db/organizations/airbridge.eno
@@ -1,0 +1,9 @@
+name: Airbridge
+website_url: https://www.airbridge.io/
+privacy_policy_url: https://www.airbridge.io/privacy-policy
+privacy_contact: compliance@ab180.co
+country: KR
+description: "Airbridge is an attribution and analytics company that unlocks next-generation strategies for marketers in the privacy era."
+
+--- notes
+--- notes

--- a/db/patterns/airbridge.eno
+++ b/db/patterns/airbridge.eno
@@ -1,0 +1,13 @@
+name: Airbridge
+category: site_analytics
+website_url: https://www.arcpublishing.com/
+organization: airbridge
+
+--- domains
+core.airbridge.io
+sdk.airbridge.io
+--- domains
+
+--- filters
+||static.airbridge.io/sdk/latest/airbridge.min.js^
+--- filters


### PR DESCRIPTION
Airbridge is providing marketing tool. It's widely used by many companies in South Korea applying modern marketing strategies on their products.

- https://www.linkedin.com/company/airbridge-hq/
- https://www.ab180.co/en/solutions/airbridge

AB180 is a company behind Airbridge. However, they seem like have everything in Airbridge instead of AB180 as AB180 even don't have privacy policy. I think AB180 is typical financial upstream of the brand: Airbridge.

- https://thevc.kr/ab180
