### PR TITLE
Add NHN Commerce by Naver (NHN)

### DIFF
--- a/db/patterns/nhn_commerce.eno
+++ b/db/patterns/nhn_commerce.eno
@@ -1,0 +1,13 @@
+name: NHN Commerce
+category: site_analytics
+website_url: https://www.nhn-commerce.com/
+organization: naver
+
+--- domains
+nhn-commerce.com
+collector-statistics.nhn-commerce.com
+--- domains
+
+--- filters
+||collector-statistics.nhn-commerce.com
+--- filters


### PR DESCRIPTION
**This PR requires explicit review.**

refs https://github.com/yous/YousList/pull/255
refs http://www.nhn.com/en_US/company?tab=domesticCorporation&subTab=paymentAd

NHN Commerce is a dedicated corporation even they're under NHN's control. In this case, we have two options:
- create new organization called "NHN Commerce" and register their service under "NHN Commerce"
- **(current) link "NHN Commerce" pattern into "Naver" organization**
