### PR TITLE
Add Danawa by Cowave

### DIFF
--- a/db/organizations/connectwave.eno
+++ b/db/organizations/connectwave.eno
@@ -1,0 +1,9 @@
+name: Connectwave
+website_url: https://www.danawa.com/
+privacy_policy_url: https://www.danawa.com/info/helprule_private.html
+privacy_contact: privacy@cowave.kr
+country: KR
+description: "Danawa is a price comparison site like BestBuy."
+
+--- notes
+--- notes

--- a/db/organizations/connectwave.eno
+++ b/db/organizations/connectwave.eno
@@ -3,7 +3,7 @@ website_url: https://www.danawa.com/
 privacy_policy_url: https://www.danawa.com/info/helprule_private.html
 privacy_contact: privacy@cowave.kr
 country: KR
-description: "Danawa is a price comparison site like BestBuy."
+description: "ConnectWave Co Ltd, formerly DANAWA Co., Ltd, is a Korea-based company mainly engaged in the operation of online price comparison websites."
 
 --- notes
 --- notes

--- a/db/patterns/danawa.eno
+++ b/db/patterns/danawa.eno
@@ -1,0 +1,14 @@
+name: Danawa
+category: advertising
+website_url: https://danawa.com/
+organization: connectwave
+
+--- domains
+ad.danawa.com
+las.danawa.com
+--- domains
+
+--- filters
+||ad.danawa.com
+||las.danawa.com
+--- filters

--- a/db/patterns/danawa.eno
+++ b/db/patterns/danawa.eno
@@ -9,6 +9,6 @@ las.danawa.com
 --- domains
 
 --- filters
-||ad.danawa.com
-||las.danawa.com
+||ad.danawa.com^$3p
+||las.danawa.com^
 --- filters


### PR DESCRIPTION
refs https://github.com/yous/YousList/pull/255
refs http://www.ftc.go.kr/bizCommPop.do?wrkr_no=1178140065 (requires English captcha)

Danawa is a price comparison site like BestBuy. Unfortunately, they don't offer English version of website or privacy policy.

<details>
<summary>Their info from `ftc.co.kr` (Korean Fair Trade Commission)</summary>

Company Name:

```

business name | Connect Wave Co., Ltd.

```

Domains:

```
www.danawa.com
www.danawa.com hi-farm.com www.farmtail.net www.fivecolor.co.kr www.makeglob.com www.ssandomain.com www.prshop.com www.shopinside.net www.makefran.co.
www.playauto.co.kr www.plto.com www.playauto.freebill.co.kr
```

</details>

**Notes**

- `las.danawa.com` is only accessible through their mobile application, confirmed on iOS
- `ad.danawa.com` is for self-promtion