### PR TITLE
Add Smartlog by Squares

### DIFF
--- a/db/organizations/squares.eno
+++ b/db/organizations/squares.eno
@@ -1,0 +1,9 @@
+name: Squares
+website_url: https://team.qshop.ai/
+privacy_policy_url: https://smlog.co.kr/2020/policy_global_agree.html
+privacy_contact: sqs@squares.ai
+country: KR
+description: "Squares is a web based platform service company developing fault click mitigation and website builder."
+
+--- notes
+--- notes

--- a/db/patterns/smartlog.eno
+++ b/db/patterns/smartlog.eno
@@ -1,0 +1,13 @@
+name: Smartlog
+category: site_analytics
+website_url: https://smlog.co.kr/
+organization: squares
+
+--- domains
+smlog.co.kr
+--- domains
+
+--- filters
+||a*.smlog.co.kr^
+||cdn.smlog.co.kr^$3p
+--- filters


### PR DESCRIPTION
refs https://github.com/yous/YousList/pull/255

They're using multiple domains to host their homepage. All are owned by `squares.ai` since they have a privacy contact under `squares.ai`.

- `qshop.ai`
- `squares.ai`
- `smlog.co.kr`
