### PR TITLE
Remove problematic filters from OneTrust CMP detection

### DIFF
--- a/db/patterns/onetrust.eno
+++ b/db/patterns/onetrust.eno
@@ -9,8 +9,6 @@ onetrust.com
 
 --- filters
 ###onetrust-banner-sdk
-###onetrust-consent-sdk
-##.onetrust-pc-dark-filter
 ###cookie-preferences
 ###consent_blackbar
 ||onetrust.com^$third-party


### PR DESCRIPTION
Exception rules were pushed to Ghostery filters (adblocker-filters) but the origin is at TrackerDB.

I don't know removing these rules is a good step for TrackerDB because they're required to detect OneTrust CMPs.