### PR TITLE
Add Acecounter by Naver

### DIFF
--- a/db/patterns/acecounter.eno
+++ b/db/patterns/acecounter.eno
@@ -1,0 +1,14 @@
+name: Acecounter
+category: site_analytics
+website_url: https://www.home.acecounter.com/
+organization: naver
+
+--- domains
+acecounter.com
+cr.acecounter.com
+www.home.acecounter.com
+--- domains
+
+--- filters
+||cr.acecounter.com^
+--- filters


### PR DESCRIPTION
refs https://www.home.acecounter.com/
refs https://www.home.acecounter.com/banner-ads-analysis
refs https://www.ftc.go.kr/bizCommPop.do?wrkr_no=2208690089&apv_perm_no=
refs https://github.com/yous/YousList/pull/255/files#diff-439cb660fd781cb9fe5038b20c8de144aa5070b1d7c790e25e85d5436e867822R272

Acecounter is Korean site analytics solution developed by NHN (= Naver).