### PR TITLE
chore: replace webtrekk script with specific filters

### DIFF
--- a/db/patterns/webtrekk.eno
+++ b/db/patterns/webtrekk.eno
@@ -25,6 +25,9 @@ wt-safetag.com
 ||webtrekk-asia.net^$3p
 ||webtrekk.de/^$3p
 ||webtrekk.net^$3p
+||static.wertpapiere.ing.de/js/gcoconfig/production/webtrekk-production_dr.js
+||static.wertpapiere.ing.de/lib/smarthouse/frameworks/webtrekk.min.js
+||static.wertpapiere.ing.de/lib/smarthouse/frameworks/webtrekk-safetag.js
 --- filters
 
 ghostery_id: 269

--- a/db/patterns/webtrekk.eno
+++ b/db/patterns/webtrekk.eno
@@ -17,7 +17,9 @@ wt-safetag.com
 --- domains
 
 --- filters
-/webtrekk*.js^
+/webtrekk_gdpr.js
+/webtrekk_gdpr.min.js
+/webtrekk_mediaTracking.min.js
 ||cdn.wbtrk.net/js/geid.min.js
 ||responder.wt-safetag.com^$3p
 ||webtrekk-asia.net^$3p


### PR DESCRIPTION
refs https://github.com/ghostery/broken-page-reports/issues/434

We have a site breakage issue on `wertpapiere.ing.de`. The website needs to load the following file:

```
https://static.wertpapiere.ing.de/lib/smarthouse/webtrekkconfig.js?v=3500120220323
```

This is blocked by:

```adb
/webtrekk*.js^
```

I added safe filters from easylist and broken page reports.