### PR TITLE
Remove asset hosts from wistia.eno

### DIFF
--- a/db/patterns/wistia.eno
+++ b/db/patterns/wistia.eno
@@ -10,8 +10,6 @@ wistia.net
 
 --- filters
 ||distillery.wistia.com^$3p
-||fast.wistia.com/assets/external/popover-v1.js
-||fast.wistia.net^$3p
 ||pipedream.wistia.com^$3p
 --- filters
 


### PR DESCRIPTION
Hello,

I'm an employee at Wistia. We've had reports from some of our customers that video playback is broken for them when using ghostery. I've removed the asset hosts from the filters here, because they block loading the code for our player that is responsible for creating the video element and connecting it to the right video. I've left in place our tracking domains, which are responsible for capturing analytics.

Thanks