### PR TITLE
OneTrust / CookieLaw cleanup

### DIFF
--- a/db/patterns/onetrust.eno
+++ b/db/patterns/onetrust.eno
@@ -8,20 +8,7 @@ onetrust.com
 --- domains
 
 --- filters
-###onetrust-banner-sdk
-###onetrust-consent-sdk
-##.onetrust-pc-dark-filter
-###cookie-preferences
-###consent_blackbar
 ||onetrust.com^$third-party
-/onetrustConsent.js
-/onetrust/consent/*
-/js/onetrust/*
-###ot-sdk-btn:not(button)
-##.ot-sdk-show-settings
-###teconsent
-/onetrust.
-/otbannersdk.js
 --- filters
 
 ghostery_id: 3740

--- a/db/patterns/optanaon.eno
+++ b/db/patterns/optanaon.eno
@@ -1,4 +1,4 @@
-name: Optanaon by OneTrust
+name: CookieLaw by OneTrust (formerly Optanaon)
 category: consent
 website_url: https://www.cookielaw.org/
 organization: onetrust
@@ -8,7 +8,20 @@ cookielaw.org
 --- domains
 
 --- filters
+/js/onetrust/*
+/onetrust.
+/onetrust/consent/*
+/onetrustConsent.js
+/otBannerSdk.js
+##.onetrust-pc-dark-filter
 ##.optanon-toggle-display
+##.ot-sdk-show-settings
+###consent_blackbar
+###cookie-preferences
+###onetrust-banner-sdk
+###onetrust-consent-sdk
+###ot-sdk-btn:not(button)
+###teconsent
 --- filters
 
 ghostery_id: 3742


### PR DESCRIPTION
Looks like that CookieLaw (formerly known as Optanon) domain is not used mostly for Consent Managment. 

Onetrust domain on the other hand is not clear. We see it's being used to determine user location, eg. https://geolocation.onetrust.com/cookieconsentpub/v1/geo/location/dnsfeed

We may wish to recategorise it in the future but as it may break the CMP functionality, lets keep it as is for now.