### PR TITLE
Fix pattern validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.105",
       "license": "CC-BY-NC-SA-4.0",
       "dependencies": {
-        "@cliqz/adblocker": "1.26.5",
+        "@cliqz/adblocker": "^1.26.16",
         "better-sqlite3": "^9.2.2",
         "enolib": "^0.8.2",
         "iso-3166-1-alpha-2": "^1.0.0",
@@ -35,32 +35,45 @@
       }
     },
     "node_modules/@cliqz/adblocker": {
-      "version": "1.26.5",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-1.26.5.tgz",
-      "integrity": "sha512-hbvkcfAQdpcREf+Jim9SXIp/M5p2g2YRB5Bd+g3zlTS+cJXvyk1Hvkj9fxHs37xytWfQMYevWyGko1ZlkOAbNA==",
+      "version": "1.26.16",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-1.26.16.tgz",
+      "integrity": "sha512-NQ5WdNeiWiggDhhT/IXbsjKgH44nA9k5GlW00gUWRUpfKHCCInyDJYjM5pbHqxhgC3LkMVmXmU5vIsMUZ4RxFQ==",
       "dependencies": {
-        "@cliqz/adblocker-content": "^1.26.5",
-        "@cliqz/adblocker-extended-selectors": "^1.26.5",
-        "@remusao/guess-url-type": "^1.1.2",
-        "@remusao/small": "^1.1.2",
-        "@remusao/smaz": "^1.7.1",
-        "@types/chrome": "^0.0.225",
-        "@types/firefox-webext-browser": "^111.0.0",
-        "tldts-experimental": "^5.6.21"
+        "@cliqz/adblocker-content": "^1.26.16",
+        "@cliqz/adblocker-extended-selectors": "^1.26.16",
+        "@remusao/guess-url-type": "^1.2.1",
+        "@remusao/small": "^1.2.1",
+        "@remusao/smaz": "^1.9.1",
+        "@types/chrome": "^0.0.260",
+        "@types/firefox-webext-browser": "^120.0.0",
+        "tldts-experimental": "^6.0.14"
       }
     },
     "node_modules/@cliqz/adblocker-content": {
-      "version": "1.26.5",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-content/-/adblocker-content-1.26.5.tgz",
-      "integrity": "sha512-pcQ/Lpd0zvkxpOYx+38IQ7ZLWj38oF5tdsjm8Yq+hQ1jBu1Dwnk9LwIlYxpktidRvpMh4dGFOYUBmb4vsieEwQ==",
+      "version": "1.26.16",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-content/-/adblocker-content-1.26.16.tgz",
+      "integrity": "sha512-N1pKg1gxfpnz47w2Sjs2sg3fxFZb113ClUhitgAFSVXeIhZ+S+bCaQtvwtP0mJT+SDfUx2NsPiLwZoPjVRI3wQ==",
       "dependencies": {
-        "@cliqz/adblocker-extended-selectors": "^1.26.5"
+        "@cliqz/adblocker-extended-selectors": "^1.26.16"
       }
     },
     "node_modules/@cliqz/adblocker-extended-selectors": {
-      "version": "1.26.5",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-extended-selectors/-/adblocker-extended-selectors-1.26.5.tgz",
-      "integrity": "sha512-+81FOTJtWwk3t58XyXBotkdOp7uP9vNe6hyUQQY173Rt9X9tsErGkPW57hMP0OgVsYNIYg7/TXxHEabxTUQubw=="
+      "version": "1.26.16",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-extended-selectors/-/adblocker-extended-selectors-1.26.16.tgz",
+      "integrity": "sha512-ePXS3aD1R+0XfCnOj0L2ms0NA5AxKHfFLfw92cZ87IPY8ZEZK/sWwQCv5wawbwBmXksr0YkMfFVCiH/IQgUNBQ=="
+    },
+    "node_modules/@cliqz/adblocker/node_modules/tldts-core": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.11.tgz",
+      "integrity": "sha512-ZFcT+/fdEc5VRndQIJtArNBHsaq4udRoeE4E6cwLzGaH0dq7Ng2L7cAoea6riM2uhNFD09EDa1bN8lrfrOBCLg=="
+    },
+    "node_modules/@cliqz/adblocker/node_modules/tldts-experimental": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.11.tgz",
+      "integrity": "sha512-4Ij/BzPUYS33PcAo9cprPm8qmKNBeYw2U7WsBAMtseqbQvCIyDsnXlOWy/SKmldalPdMPsL2CLjt27+KlWBH7g==",
+      "dependencies": {
+        "tldts-core": "^6.1.11"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -224,36 +237,36 @@
       "integrity": "sha512-yvwa+aCyYI/UjeD39BnpMypG8N06l86wIDW1/PAc6ihBRnodIfZDwccxQN3n1t74wduzaz74m4ZMHZnB06567Q=="
     },
     "node_modules/@types/chrome": {
-      "version": "0.0.225",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.225.tgz",
-      "integrity": "sha512-acSFQN7X0/fjF6PSP0Ki9TlwWsEeJeh5WclMYilJSHHp+ayLDMD/YeSIUzsodwLKPZQ9h8SyiL13/pPab8M4RA==",
+      "version": "0.0.260",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.260.tgz",
+      "integrity": "sha512-lX6QpgfsZRTDpNcCJ+3vzfFnFXq9bScFRTlfhbK5oecSAjamsno+ejFTCbNtc5O/TPnVK9Tja/PyecvWQe0F2w==",
       "dependencies": {
         "@types/filesystem": "*",
         "@types/har-format": "*"
       }
     },
     "node_modules/@types/filesystem": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
-      "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.35.tgz",
+      "integrity": "sha512-1eKvCaIBdrD2mmMgy5dwh564rVvfEhZTWVQQGRNn0Nt4ZEnJ0C8oSUCzvMKRA4lGde5oEVo+q2MrTTbV/GHDCQ==",
       "dependencies": {
         "@types/filewriter": "*"
       }
     },
     "node_modules/@types/filewriter": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
-      "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ=="
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g=="
     },
     "node_modules/@types/firefox-webext-browser": {
-      "version": "111.0.1",
-      "resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-111.0.1.tgz",
-      "integrity": "sha512-mmHWdQTCT68X0hh0URrsIyWhJeFzZHaiprj6nni/CmsAmqYq27T0eZyu1ePeKJ/zuDD3wqtTzm5TwRFAso+oPw=="
+      "version": "120.0.1",
+      "resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-120.0.1.tgz",
+      "integrity": "sha512-IR+NpPC+/o9TSTelcvT/w3fXTanX3LrpVxC5EQrlQyTjyWOKFz8O2mCJQ9VuejBz4NtovCGGKacXQ/VyY63L0A=="
     },
     "node_modules/@types/har-format": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.10.tgz",
-      "integrity": "sha512-o0J30wqycjF5miWDKYKKzzOU1ZTLuA42HZ4HE7/zqTOc/jTLdQ5NhYWvsRQo45Nfi1KHoRdNhteSI4BAxTF1Pg=="
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.15.tgz",
+      "integrity": "sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -2297,32 +2310,47 @@
   },
   "dependencies": {
     "@cliqz/adblocker": {
-      "version": "1.26.5",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-1.26.5.tgz",
-      "integrity": "sha512-hbvkcfAQdpcREf+Jim9SXIp/M5p2g2YRB5Bd+g3zlTS+cJXvyk1Hvkj9fxHs37xytWfQMYevWyGko1ZlkOAbNA==",
+      "version": "1.26.16",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-1.26.16.tgz",
+      "integrity": "sha512-NQ5WdNeiWiggDhhT/IXbsjKgH44nA9k5GlW00gUWRUpfKHCCInyDJYjM5pbHqxhgC3LkMVmXmU5vIsMUZ4RxFQ==",
       "requires": {
-        "@cliqz/adblocker-content": "^1.26.5",
-        "@cliqz/adblocker-extended-selectors": "^1.26.5",
-        "@remusao/guess-url-type": "^1.1.2",
-        "@remusao/small": "^1.1.2",
-        "@remusao/smaz": "^1.7.1",
-        "@types/chrome": "^0.0.225",
-        "@types/firefox-webext-browser": "^111.0.0",
-        "tldts-experimental": "^5.6.21"
+        "@cliqz/adblocker-content": "^1.26.16",
+        "@cliqz/adblocker-extended-selectors": "^1.26.16",
+        "@remusao/guess-url-type": "^1.2.1",
+        "@remusao/small": "^1.2.1",
+        "@remusao/smaz": "^1.9.1",
+        "@types/chrome": "^0.0.260",
+        "@types/firefox-webext-browser": "^120.0.0",
+        "tldts-experimental": "^6.0.14"
+      },
+      "dependencies": {
+        "tldts-core": {
+          "version": "6.1.11",
+          "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.11.tgz",
+          "integrity": "sha512-ZFcT+/fdEc5VRndQIJtArNBHsaq4udRoeE4E6cwLzGaH0dq7Ng2L7cAoea6riM2uhNFD09EDa1bN8lrfrOBCLg=="
+        },
+        "tldts-experimental": {
+          "version": "6.1.11",
+          "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.11.tgz",
+          "integrity": "sha512-4Ij/BzPUYS33PcAo9cprPm8qmKNBeYw2U7WsBAMtseqbQvCIyDsnXlOWy/SKmldalPdMPsL2CLjt27+KlWBH7g==",
+          "requires": {
+            "tldts-core": "^6.1.11"
+          }
+        }
       }
     },
     "@cliqz/adblocker-content": {
-      "version": "1.26.5",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-content/-/adblocker-content-1.26.5.tgz",
-      "integrity": "sha512-pcQ/Lpd0zvkxpOYx+38IQ7ZLWj38oF5tdsjm8Yq+hQ1jBu1Dwnk9LwIlYxpktidRvpMh4dGFOYUBmb4vsieEwQ==",
+      "version": "1.26.16",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-content/-/adblocker-content-1.26.16.tgz",
+      "integrity": "sha512-N1pKg1gxfpnz47w2Sjs2sg3fxFZb113ClUhitgAFSVXeIhZ+S+bCaQtvwtP0mJT+SDfUx2NsPiLwZoPjVRI3wQ==",
       "requires": {
-        "@cliqz/adblocker-extended-selectors": "^1.26.5"
+        "@cliqz/adblocker-extended-selectors": "^1.26.16"
       }
     },
     "@cliqz/adblocker-extended-selectors": {
-      "version": "1.26.5",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-extended-selectors/-/adblocker-extended-selectors-1.26.5.tgz",
-      "integrity": "sha512-+81FOTJtWwk3t58XyXBotkdOp7uP9vNe6hyUQQY173Rt9X9tsErGkPW57hMP0OgVsYNIYg7/TXxHEabxTUQubw=="
+      "version": "1.26.16",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-extended-selectors/-/adblocker-extended-selectors-1.26.16.tgz",
+      "integrity": "sha512-ePXS3aD1R+0XfCnOj0L2ms0NA5AxKHfFLfw92cZ87IPY8ZEZK/sWwQCv5wawbwBmXksr0YkMfFVCiH/IQgUNBQ=="
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -2449,36 +2477,36 @@
       "integrity": "sha512-yvwa+aCyYI/UjeD39BnpMypG8N06l86wIDW1/PAc6ihBRnodIfZDwccxQN3n1t74wduzaz74m4ZMHZnB06567Q=="
     },
     "@types/chrome": {
-      "version": "0.0.225",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.225.tgz",
-      "integrity": "sha512-acSFQN7X0/fjF6PSP0Ki9TlwWsEeJeh5WclMYilJSHHp+ayLDMD/YeSIUzsodwLKPZQ9h8SyiL13/pPab8M4RA==",
+      "version": "0.0.260",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.260.tgz",
+      "integrity": "sha512-lX6QpgfsZRTDpNcCJ+3vzfFnFXq9bScFRTlfhbK5oecSAjamsno+ejFTCbNtc5O/TPnVK9Tja/PyecvWQe0F2w==",
       "requires": {
         "@types/filesystem": "*",
         "@types/har-format": "*"
       }
     },
     "@types/filesystem": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
-      "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.35.tgz",
+      "integrity": "sha512-1eKvCaIBdrD2mmMgy5dwh564rVvfEhZTWVQQGRNn0Nt4ZEnJ0C8oSUCzvMKRA4lGde5oEVo+q2MrTTbV/GHDCQ==",
       "requires": {
         "@types/filewriter": "*"
       }
     },
     "@types/filewriter": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
-      "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ=="
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g=="
     },
     "@types/firefox-webext-browser": {
-      "version": "111.0.1",
-      "resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-111.0.1.tgz",
-      "integrity": "sha512-mmHWdQTCT68X0hh0URrsIyWhJeFzZHaiprj6nni/CmsAmqYq27T0eZyu1ePeKJ/zuDD3wqtTzm5TwRFAso+oPw=="
+      "version": "120.0.1",
+      "resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-120.0.1.tgz",
+      "integrity": "sha512-IR+NpPC+/o9TSTelcvT/w3fXTanX3LrpVxC5EQrlQyTjyWOKFz8O2mCJQ9VuejBz4NtovCGGKacXQ/VyY63L0A=="
     },
     "@types/har-format": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.10.tgz",
-      "integrity": "sha512-o0J30wqycjF5miWDKYKKzzOU1ZTLuA42HZ4HE7/zqTOc/jTLdQ5NhYWvsRQo45Nfi1KHoRdNhteSI4BAxTF1Pg=="
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.15.tgz",
+      "integrity": "sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA=="
     },
     "@types/json-schema": {
       "version": "7.0.11",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "node": ">=18.0"
   },
   "dependencies": {
-    "@cliqz/adblocker": "1.26.5",
+    "@cliqz/adblocker": "^1.26.16",
     "better-sqlite3": "^9.2.2",
     "enolib": "^0.8.2",
     "iso-3166-1-alpha-2": "^1.0.0",


### PR DESCRIPTION
Multiple new patterns were not added to the adblocker engine due to missing ghostery_id which was meant to be optional. With latest @cliqz/adblocker the problem is solved.