### PR TITLE
Remove overly broad rule for Google recaptcha

### DIFF
--- a/db/patterns/google_recaptcha.eno
+++ b/db/patterns/google_recaptcha.eno
@@ -8,7 +8,6 @@ recaptcha.net
 --- domains
 
 --- filters
-||recaptcha.net/recaptcha/
 ||google.com/recaptcha/$frame,script
 ||gstatic.*/recaptcha/
 --- filters


### PR DESCRIPTION
Affects requests like:
https://recaptcha.net/recaptcha/api2/anchor

But these requests should be still covered by the domain.