### PR TITLE
Fix the adblocker version in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.133",
       "license": "CC-BY-NC-SA-4.0",
       "dependencies": {
-        "@cliqz/adblocker": "^1.27.3",
+        "@cliqz/adblocker": "1.27.3",
         "better-sqlite3": "^9.6.0",
         "enolib": "^0.8.2",
         "iso-3166-1-alpha-2": "^1.0.2",
@@ -19,16 +19,16 @@
         "trackerdb": "cli.js"
       },
       "devDependencies": {
-        "@types/node": "^20.12.10",
-        "@typescript-eslint/eslint-plugin": "^7.8.0",
-        "@typescript-eslint/parser": "^7.8.0",
-        "chalk": "^5.3.0",
-        "ejs": "^3.1.10",
-        "eslint": "^8.57.0",
-        "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-prettier": "^5.1.3",
-        "prettier": "^3.2.5",
-        "typescript": "^5.4.5"
+        "@types/node": "20.12.10",
+        "@typescript-eslint/eslint-plugin": "7.8.0",
+        "@typescript-eslint/parser": "7.8.0",
+        "chalk": "5.3.0",
+        "ejs": "3.1.10",
+        "eslint": "8.57.0",
+        "eslint-config-prettier": "9.1.0",
+        "eslint-plugin-prettier": "5.1.3",
+        "prettier": "3.2.5",
+        "typescript": "5.4.5"
       },
       "engines": {
         "node": ">=18.0"

--- a/package.json
+++ b/package.json
@@ -43,22 +43,22 @@
     "node": ">=18.0"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^1.27.3",
+    "@cliqz/adblocker": "1.27.3",
     "better-sqlite3": "^9.6.0",
     "enolib": "^0.8.2",
     "iso-3166-1-alpha-2": "^1.0.2",
     "tldts-experimental": "^6.1.19"
   },
   "devDependencies": {
-    "@types/node": "^20.12.10",
-    "@typescript-eslint/eslint-plugin": "^7.8.0",
-    "@typescript-eslint/parser": "^7.8.0",
-    "chalk": "^5.3.0",
-    "ejs": "^3.1.10",
-    "eslint": "^8.57.0",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-prettier": "^5.1.3",
-    "prettier": "^3.2.5",
-    "typescript": "^5.4.5"
+    "@types/node": "20.12.10",
+    "@typescript-eslint/eslint-plugin": "7.8.0",
+    "@typescript-eslint/parser": "7.8.0",
+    "chalk": "5.3.0",
+    "ejs": "3.1.10",
+    "eslint": "8.57.0",
+    "eslint-config-prettier": "9.1.0",
+    "eslint-plugin-prettier": "5.1.3",
+    "prettier": "3.2.5",
+    "typescript": "5.4.5"
   }
 }


### PR DESCRIPTION
Fix the adblocker version, so it matches exactly the version that has been used to create the release, even if installed with "npm install".

Follow-up to https://github.com/ghostery/trackerdb/issues/280