### PR TITLE
Remove old filters for eloqua

### DIFF
--- a/db/patterns/eloqua.eno
+++ b/db/patterns/eloqua.eno
@@ -9,11 +9,6 @@ en25.com
 --- domains
 
 --- filters
-/elqcfg.js
-/elqcfgxml.js
-/elqimg.js
-||eloqua.com^$3p
-||en25.com^$3p
 --- filters
 
 ghostery_id: 166


### PR DESCRIPTION
Remove the older filters for eloqua, since they appear to be outdated and cause breakage.