### PR TITLE
Update cookiebot.eno

### DIFF
--- a/db/patterns/cookiebot.eno
+++ b/db/patterns/cookiebot.eno
@@ -1,7 +1,7 @@
-name: Cookiebot by Cybot
+name: Cookiebot
 category: consent
 website_url: https://www.cybot.com/
-organization: cybot
+organization: usercentrics
 
 --- domains
 cookiebot.com


### PR DESCRIPTION
Usercentrics acquired Cybot (owner of Cookiebot) in 2021:
https://www.cookiebot.com/en/usercentrics-cookiebot-cmp/

Therefore Usercentrics is the parent company with two products: Usercentrics; Cookiebot