### PR TITLE
Archiving Cybo (acquired by Cybot)

### DIFF
--- a/db/organizations/cybot.eno
+++ b/db/organizations/cybot.eno
@@ -6,6 +6,9 @@ country: DK
 description: Cybot delivers automated ePrivacy services that enable website operators to respect and protect the privacy of their visitors. 
 
 --- notes
+Usercentrics acquired Cybot (owner of Cookiebot) in Sept, 2021:
+https://www.cookiebot.com/en/usercentrics-cookiebot-cmp/
 --- notes
 
 ghostery_id: 5429
+archived


### PR DESCRIPTION
Archiving Cybot, since it was acquired by Cybot (see also https://github.com/ghostery/trackerdb/pull/301)