### PR TITLE
Update acxiom.eno

### DIFF
--- a/db/organizations/acxiom.eno
+++ b/db/organizations/acxiom.eno
@@ -1,9 +1,9 @@
-name: Acxiom
-website_url: https://www.acxiom.com/
-privacy_policy_url: https://www.acxiom.com/about-us/privacy/
-privacy_contact: privacyshieldoptout@acxiom.com
+name: LiveRamp
+website_url: https://liveramp.com
+privacy_policy_url: https://liveramp.com/privacy
+privacy_contact: 
 country: US
-description: Acxiom is a marketing services company that uses consumer data, analytics, information technology, data integration, and consulting solutions to help companies conduct direct marketing programs. Their services include direct mail, e-mail, mobile advertising, display advertising, social media, and website personalization. Relevance-X is their hosted retargeting network.
+description: LiveRamp Holdings, Inc. offers a data connectivity platform whose services include data onboarding, the transfer of offline data online for marketing purposes.
 
 --- notes
 --- notes


### PR DESCRIPTION
In October 2018, Acxiom officially changed its name to LiveRamp.

Ref: https://en.wikipedia.org/wiki/LiveRamp#:~:text=October%2C%20and%20Acxiom%20officially%20changed%20its%20name%20to%20LiveRamp%2C%20and%20its%20ticker%20symbol%20to%20RAMP