### PR TITLE
Update insightexpress.eno

### DIFF
--- a/db/patterns/insightexpress.eno
+++ b/db/patterns/insightexpress.eno
@@ -1,6 +1,6 @@
 name: InsightExpress
 category: site_analytics
-website_url: https://www.millwardbrowndigital.com/
+website_url: https://www.kantar.com/
 organization: millward_brown
 
 --- domains


### PR DESCRIPTION
Millward Brown no longer exists and is part of Kantar Group. Org file updated separately