### PR TITLE
Update hubspot_cookies.eno

### DIFF
--- a/db/patterns/hubspot_cookies.eno
+++ b/db/patterns/hubspot_cookies.eno
@@ -4,11 +4,10 @@ website_url: http://www.hubspot.com
 organization: hubspot
 
 --- domains
-js.hs-banner.com
+hs-banner.com
 wtcfns.hubspot.com
 --- domains
 
 --- filters
-||js.hs-banner.com/v*/activity$3p
 ||wtcfns.hubspot.com^$3p
 --- filters


### PR DESCRIPTION
The banner loading from hs-banner.com is not limited to the js subdomain.

Ref doc: https://knowledge.hubspot.com/domains-and-urls/ssl-and-domain-security-in-hubspot#content-security-policy:~:text=The%20following%20domains%20and%20directives%20should%20be%20included%20to%20ensure%20full%20functionality%20on%20HubSpot%2Dhosted%20pages