### PR TITLE
Update google_tag_manager.eno

### DIFF
--- a/db/patterns/google_tag_manager.eno
+++ b/db/patterns/google_tag_manager.eno
@@ -5,12 +5,10 @@ organization: google
 
 --- domains
 googletagmanager.com
-googletagservices.com
 --- domains
 
 --- filters
-||googletagmanager.com^$3p
-||googletagservices.com^$3p
+||googletagmanager.com/gtm.js^$3p
 --- filters
 
 ghostery_id: 1283


### PR DESCRIPTION
Google Tag Manager (GTM) is loaded from a specific URL, so the original domain-only definition is too broad.

For example, many other Google tags can be loaded from the same googletagmanager.com domain *without* the use of GTM (GA tracking, Google Ads, Campaign Manager, Search Ads 360, Display and Video 360). Hence it is incorrect to categorise all these as essential.

Example Google Ads tag without GTM:
https://www.googletagmanager.com/gtag/js?id=AW-656536392

With the current definition, this would be classified as essential, which is obviously incorrect. Instead such "Google Tags" should be classified separately (I will create the files for this).

Ref: https://support.google.com/analytics/answer/9355662?hl=en