### PR TITLE
Separate Google Tags from Google Tag Manager

### DIFF
--- a/db/patterns/google_tag.eno
+++ b/db/patterns/google_tag.eno
@@ -1,0 +1,13 @@
+name: Google Tag
+category: advertising
+website_url: https://developers.google.com/tag-platform/gtagjs
+organization: google
+
+--- domains
+googletagmanager.com
+--- domains
+
+--- filters
+||googletagmanager.com/gtag/js?id=$3p
+||googletagmanager.com/gtag/destination$3p
+--- filters

--- a/db/patterns/google_tag_manager.eno
+++ b/db/patterns/google_tag_manager.eno
@@ -2,10 +2,7 @@ name: Google Tag Manager
 category: essential
 website_url: https://marketingplatform.google.com/about/tag-manager/
 organization: google
-
---- domains
-googletagmanager.com
---- domains
+alias: google_tag
 
 --- filters
 ||googletagmanager.com/gtm.js^$3p


### PR DESCRIPTION
Split Google Tags out of the main Google Tag Manager entry.

refs https://github.com/ghostery/trackerdb/pull/378