### PR TITLE
Add missing filter for Google Publisher Tag

### DIFF
--- a/db/patterns/google_publisher_tags.eno
+++ b/db/patterns/google_publisher_tags.eno
@@ -1,11 +1,12 @@
 name: Google Publisher Tags
 category: site_analytics
-website_url: 
+website_url: https://developers.google.com/publisher-tag/reference
 organization: google
 alias: google_tag_manager
 
 --- filters
 ||partner.googleadservices.com/gpt/pubads_impl
+||googletagservices.com/tag/js/gpt.js
 --- filters
 
 ghostery_id: 2453


### PR DESCRIPTION
ULR: https://www.googletagservices.com/tag/js/gpt.js
Docs: https://developers.google.com/publisher-tag/reference
Test page: https://www.drudgereport.com/

Looks like it is a legacy URL:
https://www.technicallyproduct.co.uk/online-advertising/using-google-publisher-tags-gpt-tags-dont-forget-to-update-the-hosted-library-domain/

fixes https://github.com/ghostery/trackerdb/issues/385