### PR TITLE
Update AdCalls category

### DIFF
--- a/db/patterns/adcalls.eno
+++ b/db/patterns/adcalls.eno
@@ -1,5 +1,5 @@
 name: AdCalls
-category: advertising
+category: site_analytics
 website_url: https://adcalls.com/dynamic-call-tracking/
 organization: adcalls
 


### PR DESCRIPTION
Hi!

[This pull request ](https://github.com/ghostery/trackerdb/pull/242) has added AdCalls to the db, but the comment to change the category from `site_analytics` to `advertising` was wrong. AdCalls collects anonymous session data (like search terms) and then links it to calls, so the category should be `site_analytics`.