### PR TITLE
Update google_tag_manager.eno

### DIFF
--- a/db/patterns/google_tag_manager.eno
+++ b/db/patterns/google_tag_manager.eno
@@ -6,6 +6,8 @@ alias: google_tag
 
 --- filters
 ||googletagmanager.com/gtm.js^$3p
+||googletagmanager.com/a?^$3p
+||googletagmanager.com/td?^$3p
 --- filters
 
 ghostery_id: 1283


### PR DESCRIPTION
Adding filters here to prevent such hits being classified as google_tag/advertising tags, which they are not. Rather, such requests are app telemetry signals.

Examples:

https://www.googletagmanager.com/td?id=GTM-1234567&v=3&t=t&pid=1484937399&dl=omegadm.co.uk%2F&tdp=GTM-NDMWK9;272378;0;0;0&frm=0&rtg=272378&rlo=7&slo=2&hlo=4&lst=1&z=0 - via test site I control, GTM container with no tags, no other tags present on pages.

https://www.googletagmanager.com/a?id=GTM-1234567&v=3&t=t&pid=1489918335&cv=32&rv=47v0&tc=76&tag_exp=95250753&es=1&e=gtm.init_consent&eid=-1&u=AAAAAIACAAAAAACA&ut=AAAI&h=Ag&tr=1paused.1cvt&ti=2paused.2cvt&z=0

Note: this issue arises because Google uses the same domain for GTM and for loading its Google marketing tags.