### PR TITLE
Update cookiebot.eno

### DIFF
--- a/db/patterns/cookiebot.eno
+++ b/db/patterns/cookiebot.eno
@@ -5,6 +5,7 @@ organization: usercentrics
 
 --- domains
 cookiebot.com
+cookiebot.eu
 --- domains
 
 --- filters


### PR DESCRIPTION
Started seeing this domain recently e.g. on avinode.com

consent.cookiebot.eu
consentcdn.cookiebot.eu

The TLD redirects to .com so no need for a filter imo.