### PR TITLE
Add Piwik PRO Tag Manager

### DIFF
--- a/db/organizations/cookieinformation.eno
+++ b/db/organizations/cookieinformation.eno
@@ -3,7 +3,7 @@ website_url: https://cookieinformation.com/
 privacy_policy_url: https://cookieinformation.com/cookie-and-privacy-policy/
 privacy_contact: privacy@cookieinformation.com
 country: DK
-description: Cookie Information is a Danish company that develops the consent management platform of the same name.
+description: Cookie Information is a Danish company that develops the consent management platform of the same name. In November 2023, Cookie Information merged with Piwik PRO, with Piwik PRO becoming a 100% subsidiary of Cookie Information.
 
 --- notes
 --- notes

--- a/db/organizations/piwik_pro.eno
+++ b/db/organizations/piwik_pro.eno
@@ -6,6 +6,9 @@ country: PL
 description: Piwik PRO Analytics Suite is a privacy-focused platform for tracking and analyzing user behavior on websites and other digital products. It is developed by Piwik PRO, based in Poland. Piwik PRO Analytics Suite is an ISO 27001 certified company and its product is SOC 2 type II-certified. It is used by various government and health organizations, including the Government of the Netherlands and DKMS.
 
 --- notes
+In November 2023, Piwik PRO merged with Cookie Information
+(source: https://piwik.pro/blog/piwik-pro-cookie-information-merger/).
 --- notes
 
 ghostery_id: 5433
+archived

--- a/db/patterns/piwik_pro_analytics_suite.eno
+++ b/db/patterns/piwik_pro_analytics_suite.eno
@@ -1,15 +1,13 @@
 name: Piwik PRO Analytics Suite
 category: site_analytics
-website_url: https://piwik.pro/
-organization: piwik_pro
+website_url: https://piwik.pro/web-analytics/
+organization: cookieinformation
 
 --- domains
 piwik.pro
 --- domains
 
 --- filters
-||cdn.piwik.pro/consent
-||marketing.piwik.pro/containers/
 --- filters
 
 ghostery_id: 4052

--- a/db/patterns/piwik_pro_tag_manager.eno
+++ b/db/patterns/piwik_pro_tag_manager.eno
@@ -1,0 +1,11 @@
+name: Piwik PRO Tag Manager
+category: essential
+website_url: https://piwik.pro/tag-manager/
+organization: cookieinformation
+
+--- domains
+containers.piwik.pro
+--- domains
+
+--- filters
+--- filters


### PR DESCRIPTION
Split off the Tag Manager component from Piwik PRO. Also, Piwik PRO merged with the Danish company Cookie Information (https://piwik.pro/blog/piwik-pro-cookie-information-merger/).