### PR TITLE
"DoubleClick Ad Exchange" has been rebranded as "Authorized Buyers"

### DIFF
--- a/db/patterns/doubleclick_ad_buyer.eno
+++ b/db/patterns/doubleclick_ad_buyer.eno
@@ -1,6 +1,6 @@
-name: DoubleClick Ad Exchange-Buyer
+name: Authorized Buyers
 category: advertising
-website_url: 
+website_url: https://developers.google.com/authorized-buyers/
 organization: google
 alias: google_adservices
 


### PR DESCRIPTION
Source: https://developers.google.com/authorized-buyers/