### PR TITLE
Update adobe_experience_cloud.eno

### DIFF
--- a/db/patterns/adobe_experience_cloud.eno
+++ b/db/patterns/adobe_experience_cloud.eno
@@ -14,6 +14,7 @@ sitestat.com
 --- domains
 
 --- filters
+|https://smetrics\.(.+)\?
 ||.112.2o7.net^$3p
 ||.122.2o7.net^$3p
 ||adoberesources.net/alloy/*/alloy^$3p

--- a/db/patterns/adobe_experience_cloud.eno
+++ b/db/patterns/adobe_experience_cloud.eno
@@ -14,7 +14,7 @@ sitestat.com
 --- domains
 
 --- filters
-|https://smetrics\.(.+)\?
+|https://smetrics.
 ||.112.2o7.net^$3p
 ||.122.2o7.net^$3p
 ||adoberesources.net/alloy/*/alloy^$3p


### PR DESCRIPTION
Problem: Currently any Adobe Experience Cloud setup (site-analytics) using a cname for its data collection end point (in order to mimic 1st party collection) is not being identified.

Example pixel found throughout tetrapak.com:
https://smetrics.tetrapak.com/b/ss/abtetrapakprodglobal/1/JS-2.25.0-LEWM/s26206291504293?AQB=1&ndh=1&pf=1&t=20%2F8%2F2024%2013%3A35%3A15%205%200&sdid=......

From Adobe's ref doc, the cname format is:
smetrics.example.com

My suggested regex requires some testing, but the approach should make sense.

Reference:
https://experienceleague.adobe.com/en/docs/core-services/interface/data-collection/adobe-managed-cert