### PR TITLE
Pardot is now part of Salesforce

### DIFF
--- a/db/organizations/pardot.eno
+++ b/db/organizations/pardot.eno
@@ -6,6 +6,10 @@ country: US
 description: Pardot provides interactive marketing solutions. It offers Prospect Insight, a marketing automation suite for sales and marketing professionals for web and mobile, LeadDeck Prospect Monitor, an application that allows sales and marketing teams to get real-time alerts of visitor and prospect activity and VisitorID, which allows tracking and identification of the organizations of anonymous visitors.
 
 --- notes
+In October 2012, Pardot was acquired by ExactTarget. In July 2013, ExactTarget, along with Pardot, became part of Salesforce.
+
+Source: https://web.archive.org/web/20130821193229/http://www.pardot.com/about-pardot/
 --- notes
 
 ghostery_id: 228
+archived

--- a/db/patterns/pardot.eno
+++ b/db/patterns/pardot.eno
@@ -1,7 +1,7 @@
 name: Pardot
 category: site_analytics
 website_url: https://www.pardot.com/
-organization: pardot
+organization: salesforce
 
 --- domains
 pardot.com


### PR DESCRIPTION
In October 2012, Pardot was acquired by ExactTarget. In July 2013, ExactTarget, along with Pardot, became part of Salesforce.