### PR TITLE
Update bing_maps.eno

### DIFF
--- a/db/patterns/bing_maps.eno
+++ b/db/patterns/bing_maps.eno
@@ -1,10 +1,22 @@
-name: Bing Maps
+name: Bing/Azure Maps
 category: customer_interaction
-website_url: 
+website_url: https://www.bingmapsportal.com
 organization: microsoft
 
 --- domains
 virtualearth.net
+r.bing.com
+atlas.microsoft.com
 --- domains
+
+--- filters
+r.bing.com/rp^$script
+www.bing.com/api/maps/
+www.bing.com/maps/sdk
+www.bing.com/maps/geotfe
+www.bing.com/maps/instrumentation
+www.bing.com/fd/ls/lsp.aspx
+--- filters
+
 
 ghostery_id: 3400


### PR DESCRIPTION
Bing maps domains updated based on network requests found at: https://www.volvopenta.com/about-us/dealer-locator/

From https://www.bingmapsportal.com:
Bing maps is to be deprecated: Free 30-Jun-2025, Enterprise 30-Jun-2028. All implementations will need to migrate to Azure Maps.

Azure Maps
Following the examples given at https://learn.microsoft.com/en-gb/azure/azure-maps/migrate-from-bing-maps-web-app, the main difference from pixel pov, is the use of the domain atlas.microsoft.com for the end point. That should simplify its use/detection.

- I have therefore included the atlas domain and edited the pixel name to include both versions