### PR TITLE
Update bing_maps.eno

### DIFF
--- a/db/patterns/bing_maps.eno
+++ b/db/patterns/bing_maps.eno
@@ -11,6 +11,8 @@ atlas.microsoft.com
 
 --- filters
 ||r.bing.com/rp^$script
+||www.bing.com/rp/.+\.js^$script
+||www.bing.com/rp/.+\.css^$stylesheet
 ||www.bing.com/api/maps/
 ||www.bing.com/maps/sdk
 ||www.bing.com/maps/geotfe


### PR DESCRIPTION
Bing maps is wrongly categorised as advertising. This filter fixes this.

Example https://www.volvopenta.com/about-us/dealer-locator/

Most hits are for the domain r.bing.com/rp, but if you keep refreshing www.bing.com/rp is also used. Screenshots forwarded.