### PR TITLE
Syntax fixed for the Bing Maps filters

### DIFF
--- a/db/patterns/bing_maps.eno
+++ b/db/patterns/bing_maps.eno
@@ -11,8 +11,8 @@ atlas.microsoft.com
 
 --- filters
 ||r.bing.com/rp^$script
-||www.bing.com/rp/.+\.js^$script
-||www.bing.com/rp/.+\.css^$stylesheet
+||www.bing.com/rp/*.js$script
+||www.bing.com/rp/*.css$stylesheet
 ||www.bing.com/api/maps/
 ||www.bing.com/maps/sdk
 ||www.bing.com/maps/geotfe


### PR DESCRIPTION
I noticed that regular expression have to start and end with `/`; otherwise, the engine will treat them as normal string matching. In this particular case, it is also possible to express it with a wildcard alone.

refs https://github.com/ghostery/trackerdb/pull/444