### PR TITLE
Pardot is now "Marketing Cloud Account Engagement"

### DIFF
--- a/db/patterns/pardot.eno
+++ b/db/patterns/pardot.eno
@@ -1,6 +1,6 @@
-name: Pardot
+name: Marketing Cloud Account Engagement
 category: site_analytics
-website_url: https://www.pardot.com/
+website_url: https://www.salesforce.com/marketing/b2b-automation/
 organization: salesforce
 
 --- domains


### PR DESCRIPTION
In 2022, Pardot got renamed to Marketing Cloud Account Engagement:
https://www.salesforceben.com/pardot-renamed-marketing-cloud-account-engagement/