### PR TITLE
Update yieldify.eno

### DIFF
--- a/db/patterns/yieldify.eno
+++ b/db/patterns/yieldify.eno
@@ -5,6 +5,7 @@ organization: yieldify
 
 --- domains
 yieldify.com
+yieldify-production.com
 --- domains
 
 --- filters


### PR DESCRIPTION
Found on https://www.philips.nl/c-m-ho/koffie.

Note, I have not been able to confirm with certainty that this new domain is owned by yieldify.com