### PR TITLE
Update doubleclick.eno

### DIFF
--- a/db/patterns/doubleclick.eno
+++ b/db/patterns/doubleclick.eno
@@ -8,6 +8,7 @@ organization: google
 doubleclick.net
 invitemedia.com
 adservice.google.com
+adtrafficquality.google
 --- domains
 
 --- filters


### PR DESCRIPTION
adtrafficquality.google request found on https://traveler.marriott.com/united-states/key-west/

Apart from the obvious domain matching to Google, the only reference I can find to this is: https://support.google.com/admanager/thread/293179210/how-to-remove-adtrafficquality-google-from-a-dcm-tag?hl=en

However, the person who answered looks legit imo.