### PR TITLE
Update SalesViewer and cover "gtmrkt.com"

### DIFF
--- a/db/organizations/salesviewer.eno
+++ b/db/organizations/salesviewer.eno
@@ -1,9 +1,9 @@
 name: SalesViewer
 website_url: https://www.salesviewer.com/
-privacy_policy_url: https://www.salesviewer.com/datenschutz
-privacy_contact: 
-country: 
-description: 
+privacy_policy_url: https://www.salesviewer.com/en/privacy-policy/
+privacy_contact: info@salesviewer.com
+country: DE
+description: SalesViewer is a global provider for sales intelligence and website visitor identification headquartered in Bochum, Germany.
 
 --- notes
 --- notes

--- a/db/patterns/salesviewer.eno
+++ b/db/patterns/salesviewer.eno
@@ -1,10 +1,11 @@
 name: SalesViewer
 category: site_analytics
-website_url: 
+website_url: https://www.salesviewer.com/
 organization: salesviewer
 
 --- domains
 salesviewer.com
+gtmrkt.com
 --- domains
 
 --- filters


### PR DESCRIPTION
Update the company information of SalesViewer. Also, include "gtmrkt.com" as a domain that is operated by them.

Note: I did not find an obvious link; it is based on the observation that "gtmrkt.com" redirects to www.salesviewer.com:

```
$ http gtmrkt.com
HTTP/1.1 302 Found
Access-Control-Allow-Credentials: true
Access-Control-Allow-Methods: GET, POST, OPTIONS
Content-Type: text/html; charset=UTF-8
Date: Tue, 05 Nov 2024 14:54:08 GMT
Location: https://www.salesviewer.com/
```

fixes https://github.com/ghostery/trackerdb/issues/475