### PR TITLE
Update drift.eno

### DIFF
--- a/db/patterns/drift.eno
+++ b/db/patterns/drift.eno
@@ -1,7 +1,7 @@
 name: Drift
 category: customer_interaction
-website_url: 
-organization: drift
+website_url: https://www.salesloft.com/platform/drift
+organization: salesloft
 
 --- domains
 drift.com


### PR DESCRIPTION
Salesloft Acquires Drift. February 13, 2024:

https://www.salesloft.com/company/newsroom/salesloft-acquires-drift

Product name is kept as Drift