### PR TITLE
Update richrelevance.eno

### DIFF
--- a/db/patterns/richrelevance.eno
+++ b/db/patterns/richrelevance.eno
@@ -6,6 +6,7 @@ organization: richrelevance
 --- domains
 ics0.com
 richrelevance.com
+algorecs.com
 --- domains
 
 --- filters


### PR DESCRIPTION
New domain listed on official documentation:
https://cdn.richrelevance.com/online_help/public/en/Content/Topics_Integration/json_integ_core_integ_guide/JSON%20Integration%20Overview.htm

Will update org file also for name change.