### PR TITLE
Update soasta_mpulse.eno

### DIFF
--- a/db/patterns/soasta_mpulse.eno
+++ b/db/patterns/soasta_mpulse.eno
@@ -1,6 +1,6 @@
-name: SOASTA mPulse
+name: mPulse
 category: site_analytics
-website_url: http://www.soasta.com/
+website_url: https://www.akamai.com/products/mpulse-real-user-monitoring
 organization: akamai
 
 --- domains


### PR DESCRIPTION
SOASTA was the company acquired by Akamai March 2017. The product is simply called mPulse now.

Ref: https://www.akamai.com/newsroom/press-release/akamai-completes-acquisition-of-soasta