### PR TITLE
Create locatrics.eno

### DIFF
--- a/db/patterns/locatrics.eno
+++ b/db/patterns/locatrics.eno
@@ -1,0 +1,8 @@
+name: Locatrics
+category: advertising
+website_url: https://www.locatrics.com/
+organization: it_works
+
+--- domains
+rtblab.net
+--- domains


### PR DESCRIPTION
RTBLab uses the domain www.rtblab.de (https://www.crunchbase.com/organization/rtblab)

This redirects to locatrics.com (a company owned by IT Works). I have found no news/blog articles explaining the relationship of any merger.

Tracker pixel found on https://www.ellos.se/skonhet