### PR TITLE
Update brightcove.eno

### DIFF
--- a/db/patterns/brightcove.eno
+++ b/db/patterns/brightcove.eno
@@ -4,7 +4,10 @@ website_url: https://www.brightcove.com/en/
 organization: brightcove
 
 --- domains
-brightcove.com
+admin.brightcove.com
+goku.brightcove.com
+metrics.brightcove.com
+sadmin.brightcove.com
 --- domains
 
 --- filters


### PR DESCRIPTION
Adding domain list here as brightcove.com is also used in the player api: https://apis.support.brightcove.com/playback/getting-started/overview-playback-api.html

See also update to brightcove_player.eno