### PR TITLE
Update twitter_analytics.eno

### DIFF
--- a/db/patterns/twitter_analytics.eno
+++ b/db/patterns/twitter_analytics.eno
@@ -1,5 +1,5 @@
 name: X Analytics
-category: site_analytics
+category: advertising
 website_url: https://twitter.com
 organization: twitter
 


### PR DESCRIPTION
Analytics is only available to X advertisers so it makes sense this is classified as such.

Also note the query parameter of integration=advertiser in the URL of these network requests.