### PR TITLE
Update beachfront.eno

### DIFF
--- a/db/patterns/beachfront.eno
+++ b/db/patterns/beachfront.eno
@@ -1,6 +1,7 @@
 name: Beachfront Media
 category: advertising
 website_url: http://beachfrontmedia.com/
+organization: seedtag
 
 --- domains
 bfmio.com


### PR DESCRIPTION
Missing organization entry.

According to https://www.beachfront.com/about-us:
"In the Spring of 2024, Beachfront was acquired by Seedtag".