### PR TITLE
Update truoptik.eno

### DIFF
--- a/db/patterns/truoptik.eno
+++ b/db/patterns/truoptik.eno
@@ -1,6 +1,7 @@
 name: Tru Optik
 category: site_analytics
 website_url: http://truoptik.com/
+organization: transunion
 
 --- domains
 truoptik.com


### PR DESCRIPTION
Missing organization entry.

"TransUnion has agreed to acquire Tru Optik" (Oct 2020)

From https://newsroom.transunion.com/transunion-accelerates-strategic-focus-on-identity-enabled-marketing-solutions-with-agreement-to-acquire-tru-optik/