### PR TITLE
Update viafoura.eno

### DIFF
--- a/db/patterns/viafoura.eno
+++ b/db/patterns/viafoura.eno
@@ -6,11 +6,12 @@ organization: viafoura
 --- domains
 viafoura.com
 viafoura.net
+viafoura.co
 --- domains
 
 --- filters
-||viafoura.com/app/js/vf.js
-||viafoura.net/vf.js
+||viafoura.com^$3p
+||viafoura.net^$3p
 --- filters
 
 ghostery_id: 1869


### PR DESCRIPTION
New domain found on https://www.lesoleil.com/

Tidied up existing filters to match any 3P usage. That seems to be a better match to me.