### PR TITLE
Update google_publisher_tags.eno

### DIFF
--- a/db/patterns/google_publisher_tags.eno
+++ b/db/patterns/google_publisher_tags.eno
@@ -1,5 +1,5 @@
 name: Google Publisher Tags
-category: site_analytics
+category: advertising
 website_url: https://developers.google.com/publisher-tag/reference
 organization: google
 alias: google_tag_manager
@@ -7,6 +7,8 @@ alias: google_tag_manager
 --- filters
 ||partner.googleadservices.com/gpt/pubads_impl
 ||googletagservices.com/tag/js/gpt.js
+||doubleclick.net/tag/js/gpt.js
+||googlesyndication.com/tag/js/gpt.js
 --- filters
 
 ghostery_id: 2453


### PR DESCRIPTION
From Ref: https://developers.google.com/publisher-tag/guides/get-started

"The Google Publisher Tag (GPT) is an ad tagging library for Google Ad Manager." - to me this makes this tracker category = advertising.

Example code from Google shows new domains to load the library: https://developers.google.com/publisher-tag/guides/general-best-practices#load_from_an_official_source.