### PR TITLE
Update doubleclick.eno

### DIFF
--- a/db/patterns/doubleclick.eno
+++ b/db/patterns/doubleclick.eno
@@ -1,4 +1,4 @@
-name: DoubleClick
+name: Google Marketing Platform
 category: advertising
 website_url: https://marketingplatform.google.com/about/enterprise/
 organization: google


### PR DESCRIPTION
Google rebranded DoubleClick to Google Marketing Platform in 2018, so I recon it's time to update the name!

https://en.wikipedia.org/wiki/DoubleClick#:~:text=In%20June%202018%2C%20Google%20announced,became%20Google%20Ad%20Manager%20360.