### PR TITLE
Update google_adsense.eno

### DIFF
--- a/db/patterns/google_adsense.eno
+++ b/db/patterns/google_adsense.eno
@@ -5,7 +5,6 @@ organization: google
 alias: google_syndication
 
 --- filters
-||ade.googlesyndication.com/ddm/activity_ext
 ||adservice.google.com/adsid/integrator.js
 ||feedads.g.doubleclick.net^$3p
 ||google.com/adsense/domains/caf.js
@@ -14,15 +13,7 @@ alias: google_syndication
 ||google.com/afsonline/show_afs_ads.js
 ||google.com/uds/afs
 ||googleadservices.com/pagead/aclk
-||googlesyndication.com/apps/domainpark/
-||googlesyndication.com/pagead/
-||googlesyndication.com/simgad/
-||pagead2.googlesyndication.com/activeview
-||pagead2.googlesyndication.com/bg
-||pagead2.googlesyndication.com/pagead/osd.js
-||pagead2.googlesyndication.com/pub-config/*/ca-pub-*.js^$3p
 ||partner.googleadservices.com/gampad/
-||tpc.googlesyndication.com/sodar
 ||fundingchoicesmessages.google.com
 --- filters
 


### PR DESCRIPTION
Google is using the domain googlesyndication.com for many purposes related to Ads, not just Adsense. For example, this filter is flagging the use of Adsense when we know for certain it is not in use on a site.

I have therefore removed all googlesyndication.com filters. Instead these domains will be picked up by the google_syndication.eno pattern. Both are category = advertising, so this feels like a cleaner and more robust approach.