### PR TITLE
Update google_website_optimizer.eno

### DIFF
--- a/db/patterns/google_website_optimizer.eno
+++ b/db/patterns/google_website_optimizer.eno
@@ -4,6 +4,10 @@ website_url: https://www.google.com/analytics/siteopt/prev
 organization: google
 alias: google_analytics
 
+--- domains
+googleoptimize.com
+--- domains
+
 --- filters
 ||google-analytics.com/siteopt.js
 --- filters


### PR DESCRIPTION
This is a deprecated product from Google with no official pages visible. However, tracker scripts can still be found on pages e.g. 

https://www.easyjet.com/en/help/contact