### PR TITLE
Update shopify_stats.eno

### DIFF
--- a/db/patterns/shopify_stats.eno
+++ b/db/patterns/shopify_stats.eno
@@ -1,10 +1,11 @@
 name: Shopify Stats
-category: advertising
+category: site_analytics
 website_url: https://www.shopify.com/
 organization: shopify
 
 --- domains
 shopify.com
+stats.myshopify.com
 --- domains
 
 --- filters


### PR DESCRIPTION
category did not look right for this...

when I visit https://stats.shopify.com/, it tells me to go to stats.myshopify.com instead (powered by Shopify).