### PR TITLE
Update triggerbee.eno

### DIFF
--- a/db/patterns/triggerbee.eno
+++ b/db/patterns/triggerbee.eno
@@ -5,6 +5,7 @@ organization: triggerbee
 
 --- domains
 triggerbee.com
+t.myvisitors.se
 --- domains
 
 --- filters


### PR DESCRIPTION
Extra domain found in Triggerbee documentation: https://help.triggerbee.com/article/428-install-triggerbee-on-your-website (bottom of page)