### PR TITLE
Update leadoo.eno

### DIFF
--- a/db/patterns/leadoo.eno
+++ b/db/patterns/leadoo.eno
@@ -4,9 +4,9 @@ website_url: https://leadoo.com/
 organization: leadoo
 
 --- domains
-anl.leadoo.com
+leadoo.com
 --- domains
 
 --- filters
-||anl.leadoo.com^
+||leadoo.com^$3p
 --- filters


### PR DESCRIPTION
Setting this to allow any subdomain to be detected.

New domain bot.leadoo.com found on https://www.securitas.se