### PR TITLE
Update adobe_experience_cloud.eno

### DIFF
--- a/db/patterns/adobe_experience_cloud.eno
+++ b/db/patterns/adobe_experience_cloud.eno
@@ -29,8 +29,8 @@ rum.hlx.page
 ||nedstat.com^$3p
 ||omtrdc.net^$3p
 ||sitestat.com^$3p
-||rum.hlx.page/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js
-/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js
+||rum.hlx.page/.rum/@adobe/helix-rum-js@%5E2/dist/rum-standalone.js
+/.rum/@adobe/helix-rum-js@%5E2/dist/rum-standalone.js
 --- filters
 
 ghostery_id: 19

--- a/db/patterns/adobe_experience_cloud.eno
+++ b/db/patterns/adobe_experience_cloud.eno
@@ -29,7 +29,8 @@ rum.hlx.page
 ||nedstat.com^$3p
 ||omtrdc.net^$3p
 ||sitestat.com^$3p
-||rum.hlx.page/.rum/@adobe/helix-rum-js
+||rum.hlx.page/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js
+/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js
 --- filters
 
 ghostery_id: 19

--- a/db/patterns/adobe_experience_cloud.eno
+++ b/db/patterns/adobe_experience_cloud.eno
@@ -12,6 +12,7 @@ imageg.net
 nedstat.com
 omtrdc.net
 sitestat.com
+rum.hlx.page
 --- domains
 
 --- filters
@@ -28,6 +29,7 @@ sitestat.com
 ||nedstat.com^$3p
 ||omtrdc.net^$3p
 ||sitestat.com^$3p
+||rum.hlx.page/.rum/@adobe/helix-rum-js
 --- filters
 
 ghostery_id: 19


### PR DESCRIPTION
According to Adobe Experience Manager documentation: https://www.aem.live/developer/rum

"If your website is not built using AEM Edge Delivery Services, it is recommended to set up Real Use Monitoring in standalone mode."

Example rum.hlx.page script found on https://www.astrazeneca.se

Filter added because of the likely possibility Adobe would use the same domain for other products.

AEM is part of the Adobe Experience Cloud product suite: https://en.wikipedia.org/wiki/Adobe_Experience_Cloud. Hence this file appears the most appropriate place for it