### PR TITLE
Update cloudflare.eno

### DIFF
--- a/db/patterns/cloudflare.eno
+++ b/db/patterns/cloudflare.eno
@@ -7,6 +7,7 @@ organization: cloudflare
 cloudflare.com
 cloudflare.net
 cloudflarestream.com
+pages.dev
 --- domains
 
 ghostery_id: 3458


### PR DESCRIPTION
pages.dev domain is part of, and redirects to, https://pages.cloudflare.com/

Found on https://www.atlascopco.com/sv-se