### PR TITLE
Update contentful_gmbh.eno

### DIFF
--- a/db/patterns/contentful_gmbh.eno
+++ b/db/patterns/contentful_gmbh.eno
@@ -6,6 +6,7 @@ organization: contentful_gmbh
 --- domains
 ctfassets.net
 cdn.contentful.com
+ninetailed.co
 --- domains
 
 ghostery_id: 3473


### PR DESCRIPTION
New domain found on https://www.chilli.se

Contentful acquired Ninetailed in 2024: https://www.contentful.com/blog/welcoming-ninetailed-contentful/