### PR TITLE
Add google shortcut domains

### DIFF
--- a/db/patterns/firebaseio.com.eno
+++ b/db/patterns/firebaseio.com.eno
@@ -5,6 +5,8 @@ organization: google
 
 --- domains
 firebaseio.com
+page.link
+search.app.goo.gl
 --- domains
 
 ghostery_id: 3550

--- a/db/patterns/google.eno
+++ b/db/patterns/google.eno
@@ -42,6 +42,8 @@ google.rs
 google.ru
 google.se
 google.tn
+search.app
+g.co
 --- domains
 
 ghostery_id: 3579


### PR DESCRIPTION
fixes #718

--

search.app.goo.gl - Firebase DynamicLink
page.link - Firebase DynamicLink
search.app - Android in-app shortcut link path
g.co - Google internal shortcut link path

Firebase DynamicLink document - https://firebase.google.com/docs/dynamic-links Firebase DynamicLink error page - https://search.app.goo.gl/?_imcp=1 BleepingComputer: Mysterious 'search.app' link - https://www.bleepingcomputer.com/news/security/googles-mysterious-searchapp-links-leave-android-users-concerned/ Reddit: Mysterious 'search.app' link - https://www.reddit.com/r/Android/comments/1gmlto1/googles_mysterious_searchapp_links_leave_android/