### PR TITLE
Add `connect.klm.com` to AirFrance Connect

### DIFF
--- a/db/patterns/airfrance-connect.eno
+++ b/db/patterns/airfrance-connect.eno
@@ -5,8 +5,10 @@ organization: airfranceklm
 
 --- domains
 connect.airfrance.com
+connect.klm.com
 --- domains
 
 --- filters
 ||connect.airfrance.com/ach/api/event^
+||connect.klm.com/ach/api/event^
 --- filters


### PR DESCRIPTION
This adds `connect.klm.com` to AirFrance Connect file. Both two airlines have a complete same system but with different font.