### PR TITLE
Update filters snowplow.eno

### DIFF
--- a/db/patterns/snowplow.eno
+++ b/db/patterns/snowplow.eno
@@ -1,6 +1,6 @@
 name: Snowplow
 category: site_analytics
-website_url: 
+website_url: https://snowplow.io/
 organization: snowplow
 
 --- domains
@@ -16,6 +16,8 @@ snplow.net
 ||d346whrrklhco7.cloudfront.net/sa-tracker-2-7-0.js
 ||d78fikflryjgj.cloudfront.net/lib/snowplow/2.0.0.js
 ||dc8xl0ndzn2cb.cloudfront.net/sp.js
+/sp.js^$script
+/snowplow_*.js^$script
 --- filters
 
 ghostery_id: 2671


### PR DESCRIPTION
Like many site_analytics tools these days, Snowplow recommend self hosting their tracker library i.e. using a 1P domain: https://docs.snowplow.io/docs/sources/trackers/javascript-trackers/web-tracker/tracker-setup/hosting-the-javascript-tracker/self-hosting-the-javascript-tracker-aws/

They even recommend renaming the js file to a random string, so this will be tricky to detect. However it appears most users keep sp.js or snowplow*.js as the filename.

Example: https://www.boozt.com/se/sv using a 2021 file: https://resources.booztcdn.com/snowplow/snowplow_2.18.2.js