### PR TITLE
Update cookieyes.eno

### DIFF
--- a/db/patterns/cookieyes.eno
+++ b/db/patterns/cookieyes.eno
@@ -6,4 +6,9 @@ organization: cookieyes
 --- domains
 cdn-cookieyes.com
 log.cookieyes.com
+cookieyes.com
 --- domains
+
+--- filters
+||cookieyes.com^$3p
+--- filters


### PR DESCRIPTION
Using a general filter here to capture any subdomain and hence minimise the maintenance!

directory.cookieyes.com found on https://www.schoolstatus.com/