### PR TITLE
Update salesforce.com.eno

### DIFF
--- a/db/patterns/salesforce.com.eno
+++ b/db/patterns/salesforce.com.eno
@@ -1,5 +1,5 @@
 name: Salesforce
-category: advertising
+category: site_analytics
 website_url: https://www.salesforce.com/eu/
 organization: salesforce
 


### PR DESCRIPTION
Revisiting this category. From https://en.wikipedia.org/wiki/Salesforce

"Salesforce, Inc. is an American cloud-based software company headquartered in San Francisco, California. It provides applications focused on sales, customer service, marketing automation, e-commerce, analytics, artificial intelligence, and application development."

site_analytics feels a better fit.

I think originally I was over influenced by their website emphasis on: "marketing automation".