### PR TITLE
fix: risky block filters and duplicate `ghostery_id`

### DIFF
--- a/db/patterns/segment.eno
+++ b/db/patterns/segment.eno
@@ -14,9 +14,5 @@ t.arcade.show
 --- filters
 ||d2dq2ahtl5zl1z.cloudfront.net^$3p
 ||d47xnnr8b1rki.cloudfront.net^$3p
-||segment.com^$3p
-||segment.io^$3p
 ||t.arcade.show^$3p
 --- filters
-
-ghostery_id: 933


### PR DESCRIPTION
refs https://github.com/ghostery/broken-page-reports/pull/1371