### PR TITLE
wistia: restore organization entry

### DIFF
--- a/db/patterns/wistia.eno
+++ b/db/patterns/wistia.eno
@@ -1,6 +1,7 @@
 name: Wistia
 category: site_analytics
 website_url: https://wistia.com/ 
+organization: wistia
 alias: wistia_assets
 
 --- domains


### PR DESCRIPTION
It is not enforced by the tests, but other aliased entries also keep the organization entry explicit.