### PR TITLE
PayPal is no longer part of eBay.

### DIFF
--- a/db/organizations/paypal.eno
+++ b/db/organizations/paypal.eno
@@ -1,0 +1,10 @@
+name: PayPal
+website_url: https://www.paypal.com/
+privacy_policy_url: https://www.paypal.com/us/legalhub/paypal/privacy-full
+privacy_contact: https://www.paypal.com/us/smarthelp/contact-us/privacy
+country: US
+description: PayPal Holdings, Inc. is an American financial technology company that operates an online payments system. Founded in 1998 and headquartered in San Jose, California, PayPal enables individuals and businesses to send and receive money electronically. The company is widely used for online transactions and owns subsidiaries like Venmo and Xoom, which extend its services into peer-to-peer payments and international money transfers.
+
+--- notes
+In 2015, eBay spun off PayPal, and it became an independent company again.
+--- notes

--- a/db/patterns/paypal.eno
+++ b/db/patterns/paypal.eno
@@ -1,7 +1,7 @@
 name: PayPal
 category: customer_interaction
 website_url: https://www.paypal.com
-organization: ebay
+organization: paypal
 
 --- domains
 paypal.com


### PR DESCRIPTION
In 2015, eBay spun off PayPal.

Source: https://en.wikipedia.org/wiki/PayPal citing https://www.sec.gov/Archives/edgar/data/1633917/000119312515257108/d31081dex105.htm