### PR TITLE
General metrics and telemetry domain owned by Amazon.

### DIFF
--- a/db/patterns/amazon_metrics.eno
+++ b/db/patterns/amazon_metrics.eno
@@ -1,0 +1,12 @@
+name: Amazon Metrics
+category: site_analytics
+website_url: https://www.amazon.com/
+organization: amazon_associates
+
+--- domains
+a2z.com
+--- domains
+
+--- filters
+||a2z.com^$3p
+--- filters


### PR DESCRIPTION
fixes https://github.com/ghostery/trackerdb/issues/810

I did not found a homepage. Also, the name "Amazon Metrics" is somewhat generic for lack of more specific terms. My understanding is that it is a general domain used by different products internally (all within the Amazon ecosystem). If there are more generic patterns (e.g. https://github.com/ghostery/trackerdb/blob/main/db/patterns/alexa_metrics.eno), they can be represented by filters, while this new entry is intended to serve as the generic fallback.