### PR TITLE
Archive adtriba.com.eno

### DIFF
--- a/db/patterns/adtriba.com.eno
+++ b/db/patterns/adtriba.com.eno
@@ -6,4 +6,11 @@ website_url: https://www.adtriba.com/
 adtriba.com
 --- domains
 
+--- notes
+Funnel acquired Adtriba in June 2024.
+
+Source: https://funnel.io/adtriba
+--- notes
+
 ghostery_id: 3332
+archived


### PR DESCRIPTION
Funnel acquired Adtriba in June 2024.

I will create a separate new file for Funnel.io