### PR TITLE
Create globale_platform.eno

### DIFF
--- a/db/patterns/globale_platform.eno
+++ b/db/patterns/globale_platform.eno
@@ -1,0 +1,11 @@
+name: Global-e Platform
+category: utilities
+website_url: https://www.global-e.com/platform/
+organization: globale
+
+--- domains
+gepi.global-e.com
+utils.global-e.com
+web.global-e.com
+webservices.global-e.com
+--- domains


### PR DESCRIPTION
It would be nice to simply match any subdomain. However we have a separate globale_analytics.eno file for the tracking script/pixel

Subdomains found on https://www.chemistdirect.co.uk/