### PR TITLE
feat: Create new Blockthrough pattern and decommision legacy pagefair

### DIFF
--- a/db/patterns/blockthrough.eno
+++ b/db/patterns/blockthrough.eno
@@ -1,6 +1,6 @@
-name: PageFair
+name: Blockthrough
 category: customer_interaction
-website_url: https://pagefair.com/
+website_url: https://blockthrough.com/
 organization: blockthrough
 
 --- domains
@@ -17,5 +17,3 @@ pagefair.net
 ||pagefair.net^$3p
 ||s3.amazonaws.com/asset.pagefair.com
 --- filters
-
-ghostery_id: 1628


### PR DESCRIPTION
**Description**

PageFair has been acquired by Blockthrough ([announcement](https://blockthrough.com/blog/pagefair-is-joining-forces-with-blockthrough/#:~:text=We%20are%20pleased%20to%20announce,experience%20helping%20publishers%20tackle%20adblocking)), and all PageFair domains now redirect to Blockthrough.

This PR updates our domain mapping to create a new Blockthrough pattern, consolidating both Blockthrough and former PageFair domains under it, instead of using the legacy PageFair company pattern.