### PR TITLE
Update nosto.com.eno

### DIFF
--- a/db/patterns/nosto.com.eno
+++ b/db/patterns/nosto.com.eno
@@ -1,10 +1,16 @@
-name: nosto
+name: Nosto
 category: site_analytics
 website_url: https://www.nosto.com/
 organization: nosto
 
 --- domains
 nosto.com
+stackla.com
 --- domains
+
+--- filters
+||nosto.com^$3p
+||stackla.com^$3p
+--- filters
 
 ghostery_id: 3719


### PR DESCRIPTION
Nosto acquired Stackla in June 2021: https://www.nosto.com/blog/stackla-acquisition/

No existing Stackla file, so this is an edit to include the domain here.

Found on https://pharmacy2u.co.uk