### PR TITLE
Create funnel.eno

### DIFF
--- a/db/patterns/funnel.eno
+++ b/db/patterns/funnel.eno
@@ -1,0 +1,12 @@
+name: Funnel
+category: site_analytics
+website_url: https://funnel.io
+organization: funnel
+
+--- domains
+adtriba.com
+--- domains
+
+--- filters
+||adtriba.com^$3p
+--- filters


### PR DESCRIPTION
Funnel acquired Adtriba in June 2024. Source: https://funnel.io/adtriba

adtriba.com domain still in use e.g. https://www.shop-apotheke.com

Note: I have not found any updated docs on the setup of the Funnel pixel i.e. using a funnel domain. Ref: https://help.funnel.io/en/articles/11054973-basic-tracking-setup-pixel-integration