### PR TITLE
adtriba.com is still in use, but now operated by Funnel.

### DIFF
--- a/db/patterns/adtriba.com.eno
+++ b/db/patterns/adtriba.com.eno
@@ -1,10 +1,15 @@
-name: AdTriba
+name: Adtriba
 category: site_analytics
-website_url: https://www.adtriba.com/
+website_url: https://funnel.io/adtriba
+organization: funnel
 
 --- domains
 adtriba.com
 --- domains
+
+--- filters
+||adtriba.com^$3p
+--- filters
 
 --- notes
 Funnel acquired Adtriba in June 2024.
@@ -13,4 +18,3 @@ Source: https://funnel.io/adtriba
 --- notes
 
 ghostery_id: 3332
-archived


### PR DESCRIPTION
Test page: https://www.shop-apotheke.com