### PR TITLE
Add IntelSat

### DIFF
--- a/db/organizations/intelsat.eno
+++ b/db/organizations/intelsat.eno
@@ -1,0 +1,9 @@
+name: Intelsat
+website_url: https://www.intelsat.com/
+privacy_policy_url: https://www.intelsat.com/privacy-policy/
+privacy_contact: https://www.intelsat.com/contact-me/?email_privacyp
+country: US
+description: Intelsat S.A. (formerly Intel-Sat, Intelsat) is a Luxembourgish-American multinational satellite services provider with corporate headquarters in Luxembourg and administrative headquarters in Tysons, Virginia, United States.
+
+--- notes
+--- notes

--- a/db/patterns/wifionboard.eno
+++ b/db/patterns/wifionboard.eno
@@ -1,0 +1,17 @@
+name: WiFi OnBoard
+category: site_analytics
+website_url: https://www.wifionboard.com/
+organization: intelsat
+
+--- domains
+wifionboard.com
+inflightinternet.com
+--- domains
+
+--- filters
+||wifi.inflightinternet.com/app/analytics/dynatrace.js^
+||adcontent.inflightinternet.com^
+||adserver.inflightinternet.com^
+||wifi.inflightinternet.com/abp/rest/v1/data
+wifi.inflightinternet.com##div[class^="CookiesRequiredNotification"]
+--- filters


### PR DESCRIPTION
This adds "IntelSat", the company behind Delta's satellite based in-flight WiFi provider. They seem to provider the satellite networking to other airlines as well but the list of companies are not confirmed. Delta-Sync provided by Viasat probably with different satellite technology is replacing this but this service is still alive through their relatively old aircrafts. T-Mobile looks like just sponsoring and partnering them not actually powering the service behind.

The actual requests to `adcontent.inflightinternet.com` and `adserver.inflightinternet.com` were not found from the actual connection test. At least, using unpaid free networking plan on board. However, they're documented through their production script source.