### PR TITLE
Update bounce_exchange.eno

### DIFF
--- a/db/patterns/bounce_exchange.eno
+++ b/db/patterns/bounce_exchange.eno
@@ -7,10 +7,14 @@ organization: wunderkind
 bounceexchange.com
 bouncex.com
 bouncex.net
+wknd.ai
+wunderkind.co
+ibx2.net
 --- domains
 
 --- filters
 ||bounceexchange.com^$3p
+||wunderkind.co^$3p
 --- filters
 
 ghostery_id: 1463


### PR DESCRIPTION
New domain tag.wknd.ai found on: https://www.cityam.com/

Domain ownership ref: https://www.netify.ai/resources/applications/wunderkind

also lists ibx2.net (and 3 others that do not show)