### PR TITLE
Update dentsu_aegis_network.eno

### DIFF
--- a/db/organizations/dentsu_aegis_network.eno
+++ b/db/organizations/dentsu_aegis_network.eno
@@ -1,9 +1,9 @@
-name: Dentsu Aegis Network
-website_url: http://www.dentsuaegisnetwork.com/
-privacy_policy_url: http://www.dentsuaegisnetwork.com/SiteServices/PrivacyandCookiePolicy
-privacy_contact: privacy@dentsuaegis.com
-country: US
-description: Aegis Media Limited operates as an independent media communications network. It offers media communications and digital network services and provides digital media solutions as well as fully integrated digital campaigns. Aegis Media operates as a subsidiary of Aegis Group plc.
+name: Dentsu
+website_url: http://www.dentsu.com/
+privacy_policy_url: https://www.dentsu.com/our-policies/privacy-notices
+privacy_contact: dpo@dentsu.com
+country: JP
+description: Dentsu is a global media, creative and customer experience management group made up of several brands. We help our clients to improve how they advertise and market, whether by print, post, email or in the digital world. We believe that the responsible use of data supports business growth and builds strong relationships between brand and consumer.
 
 --- notes
 --- notes


### PR DESCRIPTION
According to Wikipedia, the dentsu_aegis_network rebranded as simply "Dentsu" in Sep-2020: 

https://en.wikipedia.org/wiki/Dentsu#:~:text=September%202020%20Dentsu%20Group%20Inc.%20announced%20that%20its%20international%20business%20Dentsu%20Aegis%20Network%20will%20operate%20under%20the%20dentsu%20brand.

Country reference:
Tricky because of the number of subsidiaries it operates (22 according to Wikipedia). However, the parent is Dentsu and that is a Japanese company.