### PR TITLE
Update merkle_rkg.eno

### DIFF
--- a/db/patterns/merkle_rkg.eno
+++ b/db/patterns/merkle_rkg.eno
@@ -1,6 +1,6 @@
-name: Merkle RKG
-category: site_analytics
-website_url: https://www.merkleinc.com/what-we-do/digital-agency-services/rkg-now-fully-integrated-merkle
+name: Merkle
+category: advertising
+website_url: https://www.merkle.com/
 organization: dentsu_aegis_network
 
 --- domains


### PR DESCRIPTION
RKG was the name of an acquired company in 2014 - no longer applicable:  https://www.marketingdive.com/news/merkles-rkg-acquisition-say-hello-to-americas-largest-search-ad-agency/282362/

Looking at their privacy notice, their "identity offering" smells very much like an identity graph, therefore Advertising is a better category imo: https://www.merkle.com/en/privacy-policy/data-product-privacy-notice.html