### PR TITLE
Add "i-wifisupport.com" to Inmarsat

### DIFF
--- a/db/patterns/inmarsat.eno
+++ b/db/patterns/inmarsat.eno
@@ -6,7 +6,6 @@ organization: viasat
 --- domains
 inmarsat.com
 wifi.koreanair.com
-access-wifi.net
 i-wifisupport.com
 --- domains
 


### PR DESCRIPTION
This pull request adds "access-wifi.net" to "Inmarsat" which is the satellite service provider for Korean Air. In the payment page, they redirect to "korean.access-wifi.net" then callback to "wifi.koreanair.com". The request signature didn't change from last time: refs #623.