### PR TITLE
CleanTalk

### DIFF
--- a/db/organizations/clean_talk.eno
+++ b/db/organizations/clean_talk.eno
@@ -1,0 +1,6 @@
+name: CleanTalk
+website_url: https://cleantalk.org/
+privacy_policy_url: https://cleantalk.org/publicoffer#privacy
+privacy_contact: privacy@cleantalk.org
+country: US
+description: CleanTalk is a cloud-based anti-spam service for websites, providing protection against spam and malicious activity without using Captcha or other intrusive methods.

--- a/db/patterns/clean_talk.eno
+++ b/db/patterns/clean_talk.eno
@@ -1,0 +1,13 @@
+name: CleanTalk Spam Protect
+category: utilities
+website_url: https://cleantalk.org/
+organization: clean_talk
+
+--- domains
+fd.cleantalk.org
+--- domains
+
+--- filters
+||fd.cleantalk.org/api3.0/frontend_data
+/wp-content/plugins/cleantalk-spam-protect/
+--- filters


### PR DESCRIPTION
Test page: https://ki.join.de/

Example requests:
POST https://fd.cleantalk.org/api3.0/frontend_data

The plugin is typically listed under:
https://ki.join.de/wp-content/plugins/cleantalk-spam-protect/css/cleantalk-public.min.css

(Confirmed by source: https://github.com/CleanTalk/wordpress-antispam)

Source for country=US: https://cleantalk.org/contact-us Public office and mail address:
CleanTalk Inc, 111 Barclay Blvd, suite 202, Lincolnshire, IL, 60069.

fixes https://github.com/ghostery/trackerdb/issues/939