### PR TITLE
Add `sync.connectad.io`

### DIFF
--- a/db/patterns/connectad.eno
+++ b/db/patterns/connectad.eno
@@ -5,11 +5,14 @@ organization: connectad
 
 --- domains
 connected-by.connectad.io
+i.connectad.io
 sync.connectad.io
 --- domains
 
 --- filters
 ||connected-by.connectad.io/adview.php
+||i.connectad.io^
+||sync.connectad.io^
 --- filters
 
 ghostery_id: 2934


### PR DESCRIPTION
I confirmed that the script exists on the given URL: https://www.faskitchen.com/ (this doesn't happen on uBlock Origin probably because some other requests that triggered this could be blocked. The URL is categorized as unidentified for now.

fixes https://github.com/ghostery/trackerdb/issues/1046
fixes https://github.com/ghostery/trackerdb/issues/1044