### PR TITLE
Cover self-hosted Google Tag Manager entries: "https://gtm.<domain>/gtm.js?id=GTM-..."

### DIFF
--- a/db/patterns/google_tag_manager_1p.eno
+++ b/db/patterns/google_tag_manager_1p.eno
@@ -1,4 +1,4 @@
-name: Server-side Google Tag Manager
+name: Google Tag Manager (server-side)
 category: utilities
 website_url: https://developers.google.com/tag-platform/learn/sst-fundamentals/3-why-and-when-sst
 organization: google


### PR DESCRIPTION
Matches entries like:
* (Found on idealo.de) https://gtm.idealo.de/gtm.js?id=GTM-WVMX98J

Not sure how common the setup is; but if a domain has a subdomain `gtm` and serves from there `/gtm.js?id=GTM-...`, false-positives should be fairly unlikely.