### PR TITLE
Assertive Yield and Assertive Communications

### DIFF
--- a/db/organizations/assertive_communications.eno
+++ b/db/organizations/assertive_communications.eno
@@ -1,0 +1,6 @@
+name: Assertive Communications
+website_url: https://assertcom.de/
+privacy_policy_url: https://assertcom.de/en/privacy-policy/
+privacy_contact: hallo@assertcom.de
+country: DE
+description: Assertive Communications is a German agency based in Kaufering, specializing in public relations, content marketing, and community management. The company operates and markets forums and communities, and provides services such as app development and advertising solutions to enhance brand engagement.

--- a/db/organizations/assertive_yield.eno
+++ b/db/organizations/assertive_yield.eno
@@ -1,0 +1,6 @@
+name: Assertive Yield
+website_url: https://www.assertiveyield.com/
+privacy_policy_url: https://www.assertiveyield.com/privacy/
+privacy_contact: hello@assertiveyield.com
+country: NL
+description: Assertive Yield is a global company created by publishers for publishers, specializing in ad revenue management and AI optimization for the digital publishing industry. Based in The Hague, Netherlands, it offers solutions like Yield Manager and Yield Intelligence to maximize revenue and user experience through real-time data analytics.

--- a/db/patterns/assertive_communications.eno
+++ b/db/patterns/assertive_communications.eno
@@ -1,0 +1,12 @@
+name: Assertive Communications
+category: advertising
+website_url: https://assertcom.de/
+organization: assertive_communications
+
+--- domains
+assertcom.de
+--- domains
+
+--- filters
+||api.assertcom.de^$3p
+--- filters

--- a/db/patterns/assertive_yield.eno
+++ b/db/patterns/assertive_yield.eno
@@ -1,0 +1,8 @@
+name: Assertive Yield
+category: site_analytics
+website_url: https://www.assertiveyield.com/
+organization: assertive_yield
+
+--- domains
+assertiveyield.com
+--- domains

--- a/db/patterns/assertive_yield_prebid_server.eno
+++ b/db/patterns/assertive_yield_prebid_server.eno
@@ -1,0 +1,10 @@
+name: AY Prebid Server
+category: site_analytics
+website_url: https://www.assertiveyield.com/ay_prebidserver/
+organization: assertive_yield
+alias: assertive_yield
+
+--- filters
+||hq2zc2zefnwmg3wcm.ay.delivery/s2s-client-v1.js^$3p
+||hq2zc2zefnwmg3wcm.ay.delivery/client-v2.js^$3p
+--- filters

--- a/db/patterns/prebid.eno
+++ b/db/patterns/prebid.eno
@@ -9,8 +9,6 @@ prebid.org
 
 --- filters
 ||prebid.org^$3p
-||hq2zc2zefnwmg3wcm.ay.delivery/s2s-client-v1.js^$3p
-||hq2zc2zefnwmg3wcm.ay.delivery/client-v2.js^$3p
 --- filters
 
 ghostery_id: 3774


### PR DESCRIPTION
Move hq2zc2zefnwmg3wcm.ay.delivery/s2s-client-v1.js and hq2zc2zefnwmg3wcm.ay.delivery/client-v2.js to a dedicated entry (AY Prebid Server).

Found no definitive source, but the scripts are introduced by

```
* Prebid Server Client v1.1.7
*
* Â© 2018-2026 Assertive Yield B.V. All Rights Reserved.
```

And the "ay" in "ay.delivery" is likely "Assertive Yield", so linking them to the company should be safe enough.

Added also "Assertive Communications", which operates a domain that also receives Predid requests, but I was not able to verify a direct connection. To the best of my knowledge, treating them as independent companies makes most sense.