### PR TITLE
Google Maps

### DIFF
--- a/db/patterns/google_maps.eno
+++ b/db/patterns/google_maps.eno
@@ -1,0 +1,13 @@
+name: Google Maps
+category: utilities
+website_url: https://www.google.com/maps
+organization: google
+
+--- domains
+maps.googleapis.com
+maps.google.com
+--- domains
+
+--- filters
+||www.google.com/maps^
+--- filters


### PR DESCRIPTION
Detect maps.googleapis.com as Google Maps, not maps.googleapis.com (hoosting) or Google (advertising).

Example URL (found on https://snellman.com/contact/):

* https://maps.google.com/maps?q=Kungstr%C3%A4dg%C3%A5rdsgatan%2020&t=m&z=16&output=embed&iwloc=near
* https://maps.googleapis.com/maps-api-v3/api/js/64/3a/main.js
* https://www.google.com/maps/embed?origin=mfe&pb=!1m4!2m1!1sKungstr%C3%A4dg%C3%A5rdsgatan+20!5e0!6i16