### PR TITLE
Updated domains used by AdDefend

### DIFF
--- a/db/patterns/addefend.eno
+++ b/db/patterns/addefend.eno
@@ -3,7 +3,49 @@ category: advertising
 website_url: https://www.addefend.com/
 
 --- domains
+de-en-es.com
+brwsrfrm.com
+benelph.de
+addefend-platform.com
+jubbie.de
 yagiay.com
+edioca.com
+atonato.de
+mitself.net
+hirsung.de
+frantro.de
+uobsoe.com
+domself.de
+undom.net
+tisoomi-services.com
+def-service.com
+feadrope.net
+untho.de
+tisoomiservices.com
+aaroaj.com
+bupatp.com
+iefpiu.com
+qivaiw.com
+qozveo.com
+def-platform.net
+def-service.net
+mellodur.net
+outhulem.net
+skilyake.net
+utoumine.net
+builfico.de
+content-choice.de
+cussixia.de
+def-platform.de
+def-service.de
+dywolfer.de
+eltelmis.de
+expepp.de
+hobodoka.de
+intectwo.de
+itectale.de
+odillees.de
+unifini.de
 --- domains
 
 ghostery_id: 3311

--- a/db/patterns/tisoomi.eno
+++ b/db/patterns/tisoomi.eno
@@ -1,9 +1,0 @@
-name: Tisoomi
-category: advertising
-website_url: https://tisoomi-services.com/
-
---- domains
-tisoomi-services.com
---- domains
-
-ghostery_id: 3903


### PR DESCRIPTION
Linked by their MX record ("dig MX" links to mail.addefend.com).

See also:
https://www.wombatmail.com/data/mx-addefend-com.html

fixes https://github.com/ghostery/trackerdb/issues/986