### PR TITLE
added analytics.google.com to domains

### DIFF
--- a/db/patterns/adobe_experience_cloud.eno
+++ b/db/patterns/adobe_experience_cloud.eno
@@ -22,7 +22,7 @@ adoberesources.net
 ||.122.2o7.net^$3p
 ||adoberesources.net/alloy/*/alloy^$3p
 /h10000/cma/tms/metrics.js
-/metrics\..*\.(com|net|org)\/b\/(s|ss)\//
+/\/b\/ss?\/[^\/]+\/\d+\//
 ||2o7.net^$3p
 ||du8783wkf05yr.cloudfront.net^$3p
 ||hitbox.com^$3p

--- a/db/patterns/google_analytics.eno
+++ b/db/patterns/google_analytics.eno
@@ -28,6 +28,7 @@ analytics.google.com
 ||stats.g.doubleclick.net/__utm.gif
 ||stats.g.doubleclick.net/dc.js
 ||googleanalytics.com/analytics.js
+/\/g\/collect\?v=\d+&tid=G-/
 --- filters
 
 ghostery_id: 13

--- a/db/patterns/google_analytics.eno
+++ b/db/patterns/google_analytics.eno
@@ -7,6 +7,7 @@ organization: google
 google-analytics.com
 region1.google-analytics.com
 googleanalytics.com
+analytics.google.com
 --- domains
 
 --- filters

--- a/db/patterns/plausible_analytics.eno
+++ b/db/patterns/plausible_analytics.eno
@@ -1,5 +1,5 @@
 name: Plausible Analytics
-category: utilities
+category: site_analytics
 website_url: https://plausible.io/
 organization: plausible
 


### PR DESCRIPTION
in many cases GA measurement requests are sent to analytics.google.com, e.g.:
https://analytics.google.com/g/collect?v=2&tid=G-xxx