### PR TITLE
Add Wix Panorama site_analytics pattern

### DIFF
--- a/db/patterns/wix_panorama.eno
+++ b/db/patterns/wix_panorama.eno
@@ -1,0 +1,8 @@
+name: Wix Panorama
+category: site_analytics
+website_url: https://www.wix.com/
+organization: wix
+
+--- domains
+panorama.wixapps.net
+--- domains


### PR DESCRIPTION
Found on https://www.madelinekopp.com/post/freskincare
Example requests:
* should be covered: https://panorama.wixapps.net/api/v1/bulklog
* should NOT be covered: https://instafeed.codev.wixapps.net/api/facebook/getMedias?from=&count=24

Sources:

- name (Wix Panorama / fedops logger): Wix Studio community thread referencing https://panorama.wixapps.net/api/v1/bulklog (https://forum.wixstudio.com/t/failed-to-load-resource-https-panorama-wixapps-net-api-v1-bulklog/61941)
- category (site_analytics): bulk-log endpoint plus fedops.logger.sessionId cookie used for stability/effectiveness measurement
- organization (wix): CNAME chain panorama.wixapps.net → verticals.wix.com → editor.wix.com → glb-editor.wix.com confirms Wix ownership; existing db/patterns/wix.com.eno and db/patterns/wixmp.eno reuse this slug
- domain scoped to subdomain only: apex wixapps.net hosts other Wix-app endpoints that are first-party-equivalent for customer sites; broad apex coverage would over-block