### PR TITLE
Update organization from 'rythone' to 'Nexxen'

### DIFF
--- a/db/patterns/rhythmone_beacon.eno
+++ b/db/patterns/rhythmone_beacon.eno
@@ -1,7 +1,7 @@
 name: Rhythmone Beacon
 category: advertising
 website_url: 
-organization: rythmone
+organization: Nexxen
 
 --- domains
 1rx.io


### PR DESCRIPTION
Acquired by Taptica (now Nexxen) (source: https://en.wikipedia.org/wiki/RhythmOne)