### PR TITLE
Update organization from 'rythmone' to 'Nexxen'

### DIFF
--- a/db/patterns/rhythmone_beacon.eno
+++ b/db/patterns/rhythmone_beacon.eno
@@ -1,7 +1,7 @@
 name: Rhythmone Beacon
 category: advertising
 website_url: 
-organization: rythmone
+organization: Nexxen
 
 --- domains
 1rx.io

--- a/db/patterns/rhythmone_beacon.eno
+++ b/db/patterns/rhythmone_beacon.eno
@@ -1,7 +1,7 @@
 name: Rhythmone Beacon
 category: advertising
 website_url: 
-organization: Nexxen
+organization: nexxen
 
 --- domains
 1rx.io


### PR DESCRIPTION
In April 2019, RhythmOne was acquired by Taptica International that is now Nexxen.

(source: this github trackerdb/db/organizations/rhythmone.eno
--- notes
Acquired (2019), merged and renamed to Nexxen (2023)

Source: https://en.wikipedia.org/wiki/Nexxen
--- notes
)