### PR TITLE
Change tremorhub domain and add magnite domains

### DIFF
--- a/db/patterns/rubicon.eno
+++ b/db/patterns/rubicon.eno
@@ -9,6 +9,9 @@ mobsmith.com
 nearbyad.com
 rubiconproject.com
 tremorhub.com
+cdn.springserve.com
+nai-edge.ccgateway.net
+freeskreen.com
 --- domains
 
 --- filters
@@ -17,4 +20,7 @@ tremorhub.com
 ||nearbyad.com^$3p
 ||rubiconproject.com^$3p
 ||tremorhub.com^$3p
+||springserve.com^$3p
+||ccgateway.net^$3p
+||freeskreen.com^$3p
 --- filters

--- a/db/patterns/rubicon.eno
+++ b/db/patterns/rubicon.eno
@@ -8,6 +8,7 @@ dpclk.com
 mobsmith.com
 nearbyad.com
 rubiconproject.com
+tremorhub.com
 --- domains
 
 --- filters
@@ -15,4 +16,5 @@ rubiconproject.com
 ||mobsmith.com^$3p
 ||nearbyad.com^$3p
 ||rubiconproject.com^$3p
+||tremorhub.com^$3p
 --- filters

--- a/db/patterns/tremor_video.eno
+++ b/db/patterns/tremor_video.eno
@@ -5,7 +5,6 @@ organization: nexxen
 
 --- domains
 scanscout.com
-tremorhub.com
 tremormedia.com
 tremorvideo.com
 videohub.tv


### PR DESCRIPTION
Tremorhub seems to be a magnite domain as they say on their oficial page:

As described in our [Cookie Platform Policy](https://www.magnite.com/legal/platform-cookie-policy/), our advertising technology operates by using text files called “cookies” that are placed on your device. Some of these cookies include a Digital Identifier. To locate the Digital Identifiers Magnite may process, you can search through your cookies for the cookies named:

“khaos” and “ruid” (set from the rubiconproject.com domain);
“tvid”(set from the tremorhub.com domain);
“ssid” and “sst” (set from the cdn.springserve.com domain)
“ccuid” and “ccsid” (set from the nai-edge.ccgateway.net domain)
“fsk_retargeting”(set from the freeskreen.com domain).

(source: https://www.magnite.com/legal/user-choice-portal/)

I also added the aforementioned domains that appear in their documentation