### PR TITLE
Cover "stape.<TLD>" domains

### DIFF
--- a/db/patterns/stape.eno
+++ b/db/patterns/stape.eno
@@ -8,3 +8,7 @@ stape.at
 stape.be
 stape.de
 --- domains
+
+--- filters
+/^https?:\/\/([a-z0-9-]+\.)*stape\.[a-z]+([/?]|$)/$3p
+--- filters


### PR DESCRIPTION
Should match domains like "stape.io", but not domains like "stape.amazon.com".

(Special cases like "stape.uk.co" are not detected, but could be covered in the domains.)