### PR TITLE
Cover appsflyersdk.com under AppsFlyer pattern

### DIFF
--- a/db/patterns/appsflyer.eno
+++ b/db/patterns/appsflyer.eno
@@ -5,4 +5,5 @@ organization: appsflyer
 
 --- domains
 appsflyer.com
+appsflyersdk.com
 --- domains


### PR DESCRIPTION
appsflyersdk.com is AppsFlyer's mobile SDK / attribution backend — same org as the existing appsflyer.com.