### PR TITLE
Add Hubvisor organization for the hubvisor.io pattern

### DIFF
--- a/db/organizations/hubvisor.eno
+++ b/db/organizations/hubvisor.eno
@@ -1,0 +1,6 @@
+name: Hubvisor
+website_url: https://www.hubvisor.io/
+privacy_policy_url: https://www.hubvisor.io/legal/privacy
+privacy_contact: dpo@hubvisor.io
+country: FR
+description: Hubvisor SAS is a French ad tech company offering a Prebid-based header-bidding wrapper and supply-path optimization suite for publishers.

--- a/db/patterns/hubvisor.io.eno
+++ b/db/patterns/hubvisor.io.eno
@@ -1,6 +1,7 @@
 name: Hubvisor
 category: advertising
 website_url: https://hubvisor.io/
+organization: hubvisor
 
 --- domains
 hubvisor.io


### PR DESCRIPTION
Adds an organization for the existing Hubvisor pattern (`advertising`, previously without an org).

Hubvisor SAS is a Paris-based header-bidding / ad-wrapper company — its [privacy policy](https://www.hubvisor.io/legal/privacy) names "Hubvisor SAS ... 63 rue de Provence, 75009 Paris, FRANCE". The wrapper is Prebid-based: the wrapper script served from cdn.hubvisor.io (e.g. [`wrapper/01DBFDB3G8049RQWPA1JZ2HSH5/hubvisor.js`](https://cdn.hubvisor.io/wrapper/01DBFDB3G8049RQWPA1JZ2HSH5/hubvisor.js), found on meteofrance.com) bundles Prebid.js and calls the standard [Prebid Server endpoints](https://docs.prebid.org/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html) `https://pbs.hubvisor.io/openrtb2/auction` and `https://pbs.hubvisor.io/cookie_sync`.