### PR TITLE
Add Mobvista organization and Mintegral pattern for mintegral.net

### DIFF
--- a/db/organizations/mobvista.eno
+++ b/db/organizations/mobvista.eno
@@ -1,0 +1,6 @@
+name: Mobvista
+website_url: https://www.mobvista.com/
+privacy_policy_url: https://www.mobvista.com/en/privacy
+privacy_contact: privacy@mobvista.com
+country: CN
+description: Mobvista is a Chinese mobile advertising and marketing technology company whose brands include the Mintegral programmatic advertising platform.

--- a/db/patterns/mintegral.net.eno
+++ b/db/patterns/mintegral.net.eno
@@ -1,0 +1,8 @@
+name: Mintegral
+category: advertising
+website_url: https://www.mintegral.com/
+organization: mobvista
+
+--- domains
+mintegral.net
+--- domains


### PR DESCRIPTION
Adds a Mobvista organization and a Mintegral pattern for `mintegral.net`.

Mintegral is Mobvista's programmatic mobile advertising platform — Mobvista lists Mintegral under Products & Services on [mobvista.com/en](https://www.mobvista.com/en). `mintegral.net` is Mintegral's own tracking/postback backend: their official integration docs document `http://postback.mintegral.net/install` as the install-callback endpoint ([helpcenter.mintegral.com](https://helpcenter.mintegral.com/en/docs/tracking), [adv-new.mintegral.com](https://adv-new.mintegral.com/doc/en/integration/quickStart/postback)), and those same docs carry legacy `mobvista_campuuid`/`mobvista_clickid` params tying the brand to its Mobvista parent.