### PR TITLE
Add Hungry Studio organization and pattern for afafb.com

### DIFF
--- a/db/organizations/hungry_studio.eno
+++ b/db/organizations/hungry_studio.eno
@@ -1,0 +1,6 @@
+name: Hungry Studio
+website_url: https://www.hungrystudio.com/
+privacy_policy_url: https://www.hungrystudio.com/privacyus.html
+privacy_contact: privacy@hungrystudio.com
+country: HK
+description: Hungry Studio is the brand of ARETIS LIMITED, a Hong Kong mobile game developer and publisher best known for the puzzle game Block Blast!. It operates its own in-app ad mediation and player-analytics backends for its games.

--- a/db/patterns/afafb.com.eno
+++ b/db/patterns/afafb.com.eno
@@ -1,0 +1,8 @@
+name: Hungry Studio
+category: advertising
+website_url: https://www.hungrystudio.com/
+organization: hungry_studio
+
+--- domains
+afafb.com
+--- domains


### PR DESCRIPTION
Adds a Hungry Studio organization and a pattern for `afafb.com`, the in-app ad-mediation and player-analytics backend of the studio behind Block Blast!.

No example page request for this one — it's an in-app domain that we see at the DNS level, so it probably won't show up in crawl data. The hosts we observe are `mediation-receiver.afafb.com`, `mp-api.afafb.com` and `tadata.afafb.com` (the last no longer resolves). Ownership is still checkable from the web: Hungry Studio's own Block Blast site serves its news cover images from `gcm-oss.afafb.com` (e.g. `https://gcm-oss.afafb.com/news/covers/202607/5cefdb46-aabf-4d10-a7a9-d022d55e7487.jpeg`, found on [blockblast.com](https://www.blockblast.com/)), and the [share.blockblast.com](https://share.blockblast.com/) page script treats `horizon-dev.afafb.com` as one of its own hosts.

On what the hosts are: `mediation-receiver.afafb.com` is a CNAME to `gamedot-adx-alb-1894220976.us-east-2.elb.amazonaws.com`, `mp-api.afafb.com` to `shucang-realtime-web-alb-620367517.us-east-2.elb.amazonaws.com`, and [Cert Spotter](https://api.certspotter.com/v1/issuances?domain=afafb.com&include_subdomains=true&expand=dns_names) shows certificates issued for `rtb.afafb.com` and `*.rtb.afafb.com`.

Operator and country: the [privacy policy](https://www.hungrystudio.com/privacyus.html) states "The Services are operated by ARETIS LIMITED", and Google Play's verified developer block for [Block Blast!](https://play.google.com/store/apps/details?id=com.block.juggle) gives ARETIS LIMITED at 11&12&ROOF/F, 133 Wai Yip St, Kwun Tong, Hong Kong — hence `HK`. The privacy contact is in section 9 of that policy but Cloudflare-obfuscated, so it isn't in the page text; decoded it's `privacy@hungrystudio.com`.

Filed as `advertising` since the mediation host is the highest-volume one we see; happy to split the analytics hosts (`mp-api`, `tadata`) into `site_analytics` if you'd prefer.
