### PR TITLE
Attribute anti-fraud and consent vendors, including by cookies and headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ At Ghostery, we're committed to describing things exactly as they are.
 The structure of Ghostery Tracker Database is simple and consists of three main elements:
 * **categories** - [advertising, site analytics, consent management, etc.](docs/categories.md)
 * **organizations** - companies like [Google](db/organizations/google.eno) or [Meta](db/organizations/facebook.eno), but also open source software like [Matomo](db/organizations/matomo.eno)
-* **patterns** - that express various behaviors performed by organizations. For example, a pattern for [Google Analytics](db/patterns/google_analytics.eno) is categorized as [site analytics](docs/categories.md#site-analytics), but a pattern for [Google Tag Manager](db/patterns/google_tag_manager.eno) is categorized as [utilities](docs/categories.md#utilities).
+* **patterns** - that express various behaviors performed by organizations. For example, a pattern for [Google Analytics](db/patterns/google_analytics.eno) is categorized as [site analytics](docs/categories.md#site-analytics), but a pattern for [Google Tag Manager](db/patterns/google_tag_manager.eno) is categorized as [utilities](docs/categories.md#utilities). Patterns can also declare [cookie and header signals](docs/response-signals.md) to attribute requests a URL can't reveal (e.g. CNAME-cloaked vendors).
 
 ## Where is it used?
 
@@ -39,6 +39,15 @@ const urlMatches = await trackerDB.matchUrl({
 }, {
     getDomainMetadata: true,
 });
+```
+
+Pass the parsed `trackerdb.json` as a second argument to also match [cookies and headers](docs/response-signals.md) on the same matcher:
+
+```js
+const trackerDB = await loadTrackerDB(engine, trackerDBJson);
+
+trackerDB.matchCookie('datadome');
+trackerDB.matchHeader('cf-ray');
 ```
 
 ## CLI

--- a/db/organizations/imperva.eno
+++ b/db/organizations/imperva.eno
@@ -1,0 +1,5 @@
+name: Imperva
+website_url: https://www.imperva.com/
+privacy_policy_url: https://www.imperva.com/legal/privacy-policy/
+country: US
+description: Imperva is an American cybersecurity company providing application, data, and network security, including bot mitigation. It operates the Incapsula service and acquired Distil Networks in 2019.

--- a/db/organizations/kasada.eno
+++ b/db/organizations/kasada.eno
@@ -1,0 +1,4 @@
+name: Kasada
+website_url: https://www.kasada.io/
+country: AU
+description: Kasada is an Australian cybersecurity company providing bot detection and mitigation that defends web and API traffic against automated attacks.

--- a/db/patterns/akamai_bot_manager.eno
+++ b/db/patterns/akamai_bot_manager.eno
@@ -1,0 +1,20 @@
+name: Akamai Bot Manager
+category: utilities
+tags: anti-fraud
+website_url: https://www.akamai.com/products/bot-manager
+organization: akamai
+
+--- cookies
+AKA_A2
+_abck
+ak_bmsc
+bm_mi
+bm_so
+bm_sv
+bm_sz
+--- cookies
+
+--- headers
+server: AkamaiGHost
+x-akamai-transformed
+--- headers

--- a/db/patterns/aws_elb.eno
+++ b/db/patterns/aws_elb.eno
@@ -1,0 +1,8 @@
+name: AWS Elastic Load Balancing
+category: hosting
+website_url: https://aws.amazon.com/elasticloadbalancing/
+organization: amazon_associates
+
+--- cookies
+AWSALB*
+--- cookies

--- a/db/patterns/aws_waf.eno
+++ b/db/patterns/aws_waf.eno
@@ -1,0 +1,17 @@
+name: AWS WAF
+category: utilities
+tags: anti-fraud
+website_url: https://aws.amazon.com/waf/
+organization: amazon_associates
+
+--- domains
+token.awswaf.com
+--- domains
+
+--- filters
+||token.awswaf.com^$3p
+--- filters
+
+--- cookies
+aws-waf-token
+--- cookies

--- a/db/patterns/cloudflare_bot_management.eno
+++ b/db/patterns/cloudflare_bot_management.eno
@@ -1,0 +1,26 @@
+name: Cloudflare Bot Management
+category: utilities
+tags: anti-fraud
+website_url: https://www.cloudflare.com/application-services/products/bot-management/
+organization: cloudflare
+
+--- domains
+challenges.cloudflare.com
+--- domains
+
+--- filters
+||challenges.cloudflare.com/turnstile/v0/api.js
+--- filters
+
+--- cookies
+__cf_bm
+__cflb
+__cfruid
+_cfuvid
+cf_clearance
+--- cookies
+
+--- headers
+cf-ray
+server: cloudflare
+--- headers

--- a/db/patterns/cookiebot.eno
+++ b/db/patterns/cookiebot.eno
@@ -12,3 +12,7 @@ cookiebot.eu
 ||consent.cookiebot.com^$3p
 ||imgsct.cookiebot.com/1.gif^
 --- filters
+
+--- cookies
+CookieConsent
+--- cookies

--- a/db/patterns/datadome_bot_protection.eno
+++ b/db/patterns/datadome_bot_protection.eno
@@ -1,0 +1,22 @@
+name: DataDome Bot Protection
+category: utilities
+tags: anti-fraud
+website_url: https://datadome.co/products/bot-protection/
+organization: datadome
+
+--- domains
+captcha-delivery.com
+--- domains
+
+--- filters
+||captcha-delivery.com^$3p
+--- filters
+
+--- cookies
+__ddg*
+datadome
+--- cookies
+
+--- headers
+x-datadome
+--- headers

--- a/db/patterns/human_bot_defender.eno
+++ b/db/patterns/human_bot_defender.eno
@@ -1,0 +1,18 @@
+name: HUMAN Bot Defender
+category: utilities
+tags: anti-fraud
+website_url: https://www.humansecurity.com/products/bot-defender/
+organization: human_security
+
+--- domains
+human.com
+humansecurity.com
+perimeterx.com
+--- domains
+
+--- cookies
+_px3
+_pxhd
+_pxvid
+pxcts
+--- cookies

--- a/db/patterns/iab_tcf.eno
+++ b/db/patterns/iab_tcf.eno
@@ -1,0 +1,10 @@
+name: IAB TCF Consent
+category: consent
+website_url: https://iabeurope.eu/transparency-consent-framework/
+organization: iab
+
+--- cookies
+addtl_consent
+euconsent-v2
+eupubconsent-v2
+--- cookies

--- a/db/patterns/imperva_bot_protection.eno
+++ b/db/patterns/imperva_bot_protection.eno
@@ -1,0 +1,22 @@
+name: Imperva Bot Protection
+category: utilities
+tags: anti-fraud
+website_url: https://www.imperva.com/products/advanced-bot-protection-management/
+organization: imperva
+
+--- domains
+imperva.com
+incapsula.com
+--- domains
+
+--- cookies
+incap_ses_*
+nlbi_*
+reese84
+visid_incap_*
+--- cookies
+
+--- headers
+x-cdn: Incapsula
+x-iinfo
+--- headers

--- a/db/patterns/kasada_bot_defense.eno
+++ b/db/patterns/kasada_bot_defense.eno
@@ -1,0 +1,14 @@
+name: Kasada
+category: utilities
+tags: anti-fraud
+website_url: https://www.kasada.io/
+organization: kasada
+
+--- domains
+kasada.io
+--- domains
+
+--- cookies
+KP_UIDz
+KP_UIDz-ssn
+--- cookies

--- a/db/patterns/onetrust.eno
+++ b/db/patterns/onetrust.eno
@@ -26,3 +26,8 @@ cookiepro.com
 ###teconsent
 ||onetrust.com^$third-party
 --- filters
+
+--- cookies
+OptanonAlertBoxClosed
+OptanonConsent
+--- cookies

--- a/docs/response-signals.md
+++ b/docs/response-signals.md
@@ -1,0 +1,47 @@
+# Cookies & headers
+
+Besides `domains` and `filters` (which match a request by its **URL**), a pattern can also match
+on **cookies** and **response headers** — identifying a vendor the URL can't reveal, for example a
+CNAME-cloaked first-party subdomain that is really Cloudflare or DataDome.
+
+Two optional, alphabetically-sorted blocks (order is enforced by `npm run lint-patterns`):
+
+```
+--- cookies
+cf_clearance
+incap_ses_*
+--- cookies
+
+--- headers
+cf-ray
+server: cloudflare
+--- headers
+```
+
+- **cookies** — a cookie *name*, matched wherever it appears (`Set-Cookie`, the request
+  `Cookie` header, or the cookie jar). A trailing `*` is a prefix wildcard (`incap_ses_*`, `__ddg*`).
+- **headers** — a response header as `name` (presence) or `name: value` (value matched
+  case-insensitively as a substring).
+
+**Only add vendor-unique names.** Generic signals like `PHPSESSID`, `sid`, `csrf` or
+`server: nginx` match half the web — never list them.
+
+A pattern may be matched by cookies/headers alone, with no `domains` — that is the point for
+CNAME-cloaked vendors.
+
+## Matching from code
+
+`matchCookie` / `matchHeader` live on the same matcher as `matchUrl` / `matchDomain`. They are
+powered by the exported `trackerdb.json` (not the engine binary), so pass it as the second
+argument to `loadTrackerDB`:
+
+```js
+import loadTrackerDB from '@ghostery/trackerdb';
+
+const trackerDB = await loadTrackerDB(engineBytes, trackerDBJson);
+
+trackerDB.matchCookie('incap_ses_812_99');      // exact or prefix-wildcard
+trackerDB.matchHeader('cf-ray');                // header presence
+trackerDB.matchHeader('server', 'cloudflare');  // header name + value
+// → [{ pattern, category, organization }, ...]
+```

--- a/lint.js
+++ b/lint.js
@@ -166,9 +166,11 @@ function* iterPatterns() {
     // Read domains
     const domains = extractSection(source, '\n--- domains\n');
     const filters = extractSection(source, '\n--- filters\n');
+    const cookies = extractSection(source, '\n--- cookies\n');
+    const headers = extractSection(source, '\n--- headers\n');
     const notes = extractSection(source, '\n--- notes\n');
 
-    yield { path, source, metadata, domains, filters, notes };
+    yield { path, source, metadata, domains, filters, cookies, headers, notes };
   }
 }
 
@@ -198,6 +200,26 @@ function formatFile(patterns) {
       out.push(line);
     }
     out.push('--- filters');
+    out.push('');
+  }
+
+  // Format cookies (sorted, so canonical order is alphabetical and `--check` enforces it)
+  if (patterns.cookies) {
+    out.push('--- cookies');
+    for (const line of [...new Set(splitlines(patterns.cookies[2]))].sort()) {
+      out.push(line);
+    }
+    out.push('--- cookies');
+    out.push('');
+  }
+
+  // Format headers (sorted, same enforcement as cookies)
+  if (patterns.headers) {
+    out.push('--- headers');
+    for (const line of [...new Set(splitlines(patterns.headers[2]))].sort()) {
+      out.push(line);
+    }
+    out.push('--- headers');
     out.push('');
   }
 

--- a/scripts/export-json/index.js
+++ b/scripts/export-json/index.js
@@ -17,6 +17,8 @@ import { prepareDistFolder, BASE_PATH, getSpecs } from '../helpers.js';
     patterns: {},
     domains: {},
     filters: {},
+    cookies: {},
+    headers: {},
   };
 
   for (const [id, spec] of getSpecs('categories')) {
@@ -65,6 +67,8 @@ import { prepareDistFolder, BASE_PATH, getSpecs } from '../helpers.js';
           .filter((t) => t.length > 0) || [],
       domains: [],
       filters: [],
+      cookies: [],
+      headers: [],
     };
 
     const filters = spec.field('filters').optionalStringValue();
@@ -88,6 +92,28 @@ import { prepareDistFolder, BASE_PATH, getSpecs } from '../helpers.js';
         }
       }
     }
+
+    const cookies = spec.field('cookies').optionalStringValue();
+    if (cookies) {
+      for (const line of cookies.split(/[\r\n]+/g)) {
+        const trimmed = line.trim();
+        if (trimmed) {
+          db.patterns[id].cookies.push(trimmed);
+          db.cookies[trimmed] = id;
+        }
+      }
+    }
+
+    const headers = spec.field('headers').optionalStringValue();
+    if (headers) {
+      for (const line of headers.split(/[\r\n]+/g)) {
+        const trimmed = line.trim();
+        if (trimmed) {
+          db.patterns[id].headers.push(trimmed);
+          db.headers[trimmed.toLowerCase()] = id;
+        }
+      }
+    }
   }
 
   console.log('Exported categories:', Object.keys(db.categories).length);
@@ -95,6 +121,8 @@ import { prepareDistFolder, BASE_PATH, getSpecs } from '../helpers.js';
   console.log('Exported patterns:', Object.keys(db.patterns).length);
   console.log('Exported domains:', Object.keys(db.domains).length);
   console.log('Exported filters:', Object.keys(db.filters).length);
+  console.log('Exported cookies:', Object.keys(db.cookies).length);
+  console.log('Exported headers:', Object.keys(db.headers).length);
 
   writeFileSync(outputPath, JSON.stringify(db, null, 2));
 })();

--- a/scripts/export-json/index.js
+++ b/scripts/export-json/index.js
@@ -18,6 +18,7 @@ import { prepareDistFolder, BASE_PATH, getSpecs } from '../helpers.js';
     domains: {},
     filters: {},
     cookies: {},
+    cookiePrefixes: {},
     headers: {},
   };
 
@@ -97,8 +98,12 @@ import { prepareDistFolder, BASE_PATH, getSpecs } from '../helpers.js';
     if (cookies) {
       for (const line of cookies.split(/[\r\n]+/g)) {
         const trimmed = line.trim();
-        if (trimmed) {
-          db.patterns[id].cookies.push(trimmed);
+        if (!trimmed) continue;
+        db.patterns[id].cookies.push(trimmed);
+        // Split exact names from `prefix*` wildcards so the SDK can hash / trie them directly.
+        if (trimmed.endsWith('*')) {
+          db.cookiePrefixes[trimmed.slice(0, -1)] = id;
+        } else {
           db.cookies[trimmed] = id;
         }
       }
@@ -108,10 +113,22 @@ import { prepareDistFolder, BASE_PATH, getSpecs } from '../helpers.js';
     if (headers) {
       for (const line of headers.split(/[\r\n]+/g)) {
         const trimmed = line.trim();
-        if (trimmed) {
-          db.patterns[id].headers.push(trimmed);
-          db.headers[trimmed.toLowerCase()] = id;
-        }
+        if (!trimmed) continue;
+        db.patterns[id].headers.push(trimmed);
+        // Bucket by (lowercased) header name so matchHeader is a single map probe.
+        const idx = trimmed.indexOf(':');
+        const name = (idx === -1 ? trimmed : trimmed.slice(0, idx))
+          .trim()
+          .toLowerCase();
+        const value =
+          idx === -1
+            ? null
+            : trimmed
+                .slice(idx + 1)
+                .trim()
+                .toLowerCase();
+        if (!db.headers[name]) db.headers[name] = [];
+        db.headers[name].push({ value, id });
       }
     }
   }
@@ -122,7 +139,11 @@ import { prepareDistFolder, BASE_PATH, getSpecs } from '../helpers.js';
   console.log('Exported domains:', Object.keys(db.domains).length);
   console.log('Exported filters:', Object.keys(db.filters).length);
   console.log('Exported cookies:', Object.keys(db.cookies).length);
-  console.log('Exported headers:', Object.keys(db.headers).length);
+  console.log(
+    'Exported cookie prefixes:',
+    Object.keys(db.cookiePrefixes).length,
+  );
+  console.log('Exported header names:', Object.keys(db.headers).length);
 
   writeFileSync(outputPath, JSON.stringify(db, null, 2));
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,8 @@ type FromRawDetailsParams = Parameters<typeof Request.fromRawDetails>;
 type DeserializeParams = Parameters<typeof FiltersEngine.deserialize>;
 
 // The parsed trackerdb.json — needed for matchCookie/matchHeader, which are not part of the
-// (URL-oriented) adblocker engine binary.
+// (URL-oriented) adblocker engine binary. Its cookie/header indexes are pre-bucketed at export
+// time so a match is a single hash probe (wildcards: a short trie walk) with no per-load rebuild.
 export interface TrackerDBData {
   categories: Record<
     string,
@@ -19,17 +20,23 @@ export interface TrackerDBData {
       name: string;
       category: string;
       organization: string | null;
-      cookies?: string[];
-      headers?: string[];
       [key: string]: unknown;
     }
   >;
+  cookies?: Record<string, string>;
+  cookiePrefixes?: Record<string, string>;
+  headers?: Record<string, Array<{ value: string | null; id: string }>>;
 }
 
 export interface PatternMatch {
   pattern: Record<string, unknown>;
   category: Record<string, unknown> | null;
   organization: Record<string, unknown> | null;
+}
+
+interface CookieTrieNode {
+  id?: string;
+  next: Map<string, CookieTrieNode>;
 }
 
 // eslint-disable-next-line @typescript-eslint/require-await
@@ -39,42 +46,21 @@ export default async function loadTrackerDBEngine(
 ) {
   const engine = FiltersEngine.deserialize(engineBytes);
 
-  // Cookie/header lookups are built from the JSON (optional). A cookie name may come from a
-  // request `Cookie`, a response `Set-Cookie`, or the jar — the matcher does not care which.
-  const exactCookies = new Map<string, string>();
-  const prefixCookies: Array<{ prefix: string; id: string }> = [];
-  const headerMatchers: Array<{
-    name: string;
-    value: string | null;
-    id: string;
-  }> = [];
-
-  if (db) {
-    for (const id of Object.keys(db.patterns)) {
-      const p = db.patterns[id];
-      for (const c of p.cookies ?? []) {
-        if (c.endsWith('*')) prefixCookies.push({ prefix: c.slice(0, -1), id });
-        else exactCookies.set(c, id);
-      }
-      for (const h of p.headers ?? []) {
-        const idx = h.indexOf(':');
-        if (idx === -1) {
-          headerMatchers.push({
-            name: h.trim().toLowerCase(),
-            value: null,
-            id,
-          });
-        } else {
-          headerMatchers.push({
-            name: h.slice(0, idx).trim().toLowerCase(),
-            value: h
-              .slice(idx + 1)
-              .trim()
-              .toLowerCase(),
-            id,
-          });
+  // The only load-time build is a small trie over wildcard cookie prefixes; exact cookies and
+  // header buckets are used straight from the export.
+  const cookieTrie: CookieTrieNode = { next: new Map() };
+  if (db && db.cookiePrefixes) {
+    for (const [prefix, id] of Object.entries(db.cookiePrefixes)) {
+      let node = cookieTrie;
+      for (const ch of prefix) {
+        let child = node.next.get(ch);
+        if (!child) {
+          child = { next: new Map() };
+          node.next.set(ch, child);
         }
+        node = child;
       }
+      node.id = id;
     }
   }
 
@@ -93,12 +79,17 @@ export default async function loadTrackerDBEngine(
   }
 
   function cookiePatternId(name: string): string | null {
-    const hit = exactCookies.get(name);
-    if (hit) return hit;
-    for (const { prefix, id } of prefixCookies) {
-      if (name.startsWith(prefix)) return id;
+    const exact = db && db.cookies ? db.cookies[name] : undefined;
+    if (exact) return exact;
+    // Shortest registered prefix wins.
+    let node: CookieTrieNode = cookieTrie;
+    for (const ch of name) {
+      const child = node.next.get(ch);
+      if (!child) return null;
+      if (child.id !== undefined) return child.id;
+      node = child;
     }
-    return null;
+    return node.id ?? null;
   }
 
   return {
@@ -125,6 +116,7 @@ export default async function loadTrackerDBEngine(
       return engine.metadata.fromDomain(domain);
     },
 
+    // A cookie name may come from a request `Cookie`, a response `Set-Cookie`, or the jar.
     matchCookie(name: string): PatternMatch[] {
       const id = cookiePatternId(name);
       const m = id ? resolve(id) : null;
@@ -132,13 +124,15 @@ export default async function loadTrackerDBEngine(
     },
 
     matchHeader(name: string, value?: string): PatternMatch[] {
-      const n = name.toLowerCase();
+      const bucket =
+        db && db.headers ? db.headers[name.toLowerCase()] : undefined;
+      if (!bucket) return [];
       const v = value === undefined ? null : String(value).toLowerCase();
       const out: PatternMatch[] = [];
-      for (const hm of headerMatchers) {
-        if (hm.name !== n) continue;
-        if (hm.value !== null && (v === null || !v.includes(hm.value)))
+      for (const hm of bucket) {
+        if (hm.value !== null && (v === null || !v.includes(hm.value))) {
           continue;
+        }
         const m = resolve(hm.id);
         if (m) out.push(m);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,101 @@ export { Request as AdblockerRequest };
 type FromRawDetailsParams = Parameters<typeof Request.fromRawDetails>;
 type DeserializeParams = Parameters<typeof FiltersEngine.deserialize>;
 
+// The parsed trackerdb.json — needed for matchCookie/matchHeader, which are not part of the
+// (URL-oriented) adblocker engine binary.
+export interface TrackerDBData {
+  categories: Record<
+    string,
+    { name: string; color: string; description: string }
+  >;
+  organizations: Record<string, Record<string, unknown>>;
+  patterns: Record<
+    string,
+    {
+      name: string;
+      category: string;
+      organization: string | null;
+      cookies?: string[];
+      headers?: string[];
+      [key: string]: unknown;
+    }
+  >;
+}
+
+export interface PatternMatch {
+  pattern: Record<string, unknown>;
+  category: Record<string, unknown> | null;
+  organization: Record<string, unknown> | null;
+}
+
 // eslint-disable-next-line @typescript-eslint/require-await
 export default async function loadTrackerDBEngine(
   engineBytes: DeserializeParams[0],
+  db?: TrackerDBData,
 ) {
   const engine = FiltersEngine.deserialize(engineBytes);
+
+  // Cookie/header lookups are built from the JSON (optional). A cookie name may come from a
+  // request `Cookie`, a response `Set-Cookie`, or the jar — the matcher does not care which.
+  const exactCookies = new Map<string, string>();
+  const prefixCookies: Array<{ prefix: string; id: string }> = [];
+  const headerMatchers: Array<{
+    name: string;
+    value: string | null;
+    id: string;
+  }> = [];
+
+  if (db) {
+    for (const id of Object.keys(db.patterns)) {
+      const p = db.patterns[id];
+      for (const c of p.cookies ?? []) {
+        if (c.endsWith('*')) prefixCookies.push({ prefix: c.slice(0, -1), id });
+        else exactCookies.set(c, id);
+      }
+      for (const h of p.headers ?? []) {
+        const idx = h.indexOf(':');
+        if (idx === -1) {
+          headerMatchers.push({
+            name: h.trim().toLowerCase(),
+            value: null,
+            id,
+          });
+        } else {
+          headerMatchers.push({
+            name: h.slice(0, idx).trim().toLowerCase(),
+            value: h
+              .slice(idx + 1)
+              .trim()
+              .toLowerCase(),
+            id,
+          });
+        }
+      }
+    }
+  }
+
+  function resolve(id: string): PatternMatch | null {
+    if (!db) return null;
+    const pattern = db.patterns[id];
+    if (!pattern) return null;
+    const cat = db.categories[pattern.category];
+    const orgKey = pattern.organization;
+    const org = orgKey ? db.organizations[orgKey] : undefined;
+    return {
+      pattern: { key: id, ...pattern },
+      category: cat ? { key: pattern.category, ...cat } : null,
+      organization: orgKey && org ? { key: orgKey, ...org } : null,
+    };
+  }
+
+  function cookiePatternId(name: string): string | null {
+    const hit = exactCookies.get(name);
+    if (hit) return hit;
+    for (const { prefix, id } of prefixCookies) {
+      if (name.startsWith(prefix)) return id;
+    }
+    return null;
+  }
 
   return {
     ENGINE_VERSION,
@@ -33,6 +123,26 @@ export default async function loadTrackerDBEngine(
         return [];
       }
       return engine.metadata.fromDomain(domain);
+    },
+
+    matchCookie(name: string): PatternMatch[] {
+      const id = cookiePatternId(name);
+      const m = id ? resolve(id) : null;
+      return m ? [m] : [];
+    },
+
+    matchHeader(name: string, value?: string): PatternMatch[] {
+      const n = name.toLowerCase();
+      const v = value === undefined ? null : String(value).toLowerCase();
+      const out: PatternMatch[] = [];
+      for (const hm of headerMatchers) {
+        if (hm.name !== n) continue;
+        if (hm.value !== null && (v === null || !v.includes(hm.value)))
+          continue;
+        const m = resolve(hm.id);
+        if (m) out.push(m);
+      }
+      return out;
     },
   };
 }

--- a/test/db/patterns.test.js
+++ b/test/db/patterns.test.js
@@ -20,6 +20,8 @@ const FIELDS_ALLOW_LIST = [
   'category',
   'domains',
   'filters',
+  'cookies',
+  'headers',
   'name',
   'notes',
   'organization',
@@ -28,6 +30,12 @@ const FIELDS_ALLOW_LIST = [
   'archived',
   'tags',
 ];
+
+// cookie-name matcher: RFC-6265-ish token, with an optional trailing '*' prefix-wildcard
+// (e.g. incap_ses_*, visid_incap_*, __ddg*).
+const COOKIE_RE = /^[A-Za-z0-9_.-]+\*?$/;
+// response/request header matcher: header-name, optionally 'name: value'.
+const HEADER_RE = /^[A-Za-z0-9-]+(:\s?.+)?$/;
 
 function parseSpecFile(specFile) {
   return enolib.parse(
@@ -114,10 +122,45 @@ test(RESOURCE_PATH, async (t) => {
         }
       });
 
-      await t.test('has at least one domain if not a alias', () => {
+      await t.test('has at least one matchable signal if not a alias', () => {
         const domains = spec.field('domains').optionalStringValue() || '';
+        const cookies = spec.field('cookies').optionalStringValue() || '';
+        const headers = spec.field('headers').optionalStringValue() || '';
         if (!spec.field('alias').optionalStringValue()) {
-          assert.ok(domains.length > 0, `${specFile} has no domains`);
+          assert.ok(
+            domains.length > 0 || cookies.length > 0 || headers.length > 0,
+            `${specFile} has no domains, cookies, or headers`,
+          );
+        }
+      });
+
+      await t.test('has valid cookies', () => {
+        const cookies = spec.field('cookies').optionalStringValue();
+        if (cookies) {
+          for (const line of cookies.split(/[\r\n]+/g)) {
+            const trimmed = line.trim();
+            if (trimmed) {
+              assert.ok(
+                COOKIE_RE.test(trimmed),
+                `Cookie '${trimmed}' is not a valid cookie-name matcher (letters, digits, _ . -, optional trailing *).`,
+              );
+            }
+          }
+        }
+      });
+
+      await t.test('has valid headers', () => {
+        const headers = spec.field('headers').optionalStringValue();
+        if (headers) {
+          for (const line of headers.split(/[\r\n]+/g)) {
+            const trimmed = line.trim();
+            if (trimmed) {
+              assert.ok(
+                HEADER_RE.test(trimmed),
+                `Header '${trimmed}' is not a valid header matcher ('name' or 'name: value').`,
+              );
+            }
+          }
         }
       });
 
@@ -179,6 +222,27 @@ test(RESOURCE_PATH, async (t) => {
             `Domain lists overlap between: "${domain}" is included both in "${conflict}" and "${specName}"`,
           );
           domainsSeen.set(domain, specName);
+        }
+      }
+    }
+  });
+
+  await t.test('has no overlapping cookies', () => {
+    const cookiesSeen = new Map();
+    for (const specFile of specFiles) {
+      const specName = path.basename(specFile, SPEC_FILE_EXTENSION);
+      const spec = parseSpecFile(specFile);
+      const cookies = spec.field('cookies').optionalStringValue();
+      if (cookies) {
+        for (const line of cookies.split(/[\r\n]+/g)) {
+          const cookie = line.trim();
+          if (!cookie) continue;
+          const conflict = cookiesSeen.get(cookie);
+          assert.ok(
+            !conflict,
+            `Cookie lists overlap: "${cookie}" is included both in "${conflict}" and "${specName}"`,
+          );
+          cookiesSeen.set(cookie, specName);
         }
       }
     }


### PR DESCRIPTION
Adds the major bot-management vendors (Cloudflare, Akamai, DataDome, Imperva, PerimeterX/HUMAN, Kasada, AWS WAF) as `anti-fraud`, plus OneTrust/Cookiebot/IAB TCF consent cookies and AWS ELB.

Patterns can now also be matched by the **cookies** and **response headers** they set — attributing vendors a URL can't reveal (CNAME-cloaked / edge-integrated). New `--- cookies` / `--- headers` blocks (cookie names support a `prefix*` wildcard) and SDK `matchCookie` / `matchHeader`. See `docs/response-signals.md`.
